### PR TITLE
modified code to use Q_broad_new attributes in libdiffpy peak widths

### DIFF
--- a/src/diffpy/srreal/pdfcalculator.py
+++ b/src/diffpy/srreal/pdfcalculator.py
@@ -83,6 +83,11 @@ def _defineCommonInterface(cls):
         Not applied when equal zero.  Active for JeongPeakWidth model.
         [0 1/A]''')
 
+    cls.qbroad_new = propertyFromExtDoubleAttr('qbroad_new',
+        '''PDF peak broadening from non-constant instrumental broadening 
+        in Q-space.  Active for JeongPeakWidth model.
+        [0 1/A]''')
+
     cls.extendedrmin = propertyFromExtDoubleAttr('extendedrmin',
         '''Low boundary of the extended r-range, read-only.
         [A]''')

--- a/src/diffpy/srreal/peakwidthmodel.py
+++ b/src/diffpy/srreal/peakwidthmodel.py
@@ -58,6 +58,9 @@ JeongPeakWidth.delta2 = propertyFromExtDoubleAttr('delta2',
 JeongPeakWidth.qbroad = propertyFromExtDoubleAttr('qbroad',
         'PDF peak broadening from increased intensity noise at high Q.')
 
+JeongPeakWidth.qbroad_new = propertyFromExtDoubleAttr('qbroad_new',
+        'PDF peak broadening from non-constant instrumental broadening in Q-space.')
+
 # Import delayed tweaks of the extension classes.
 
 _final_imports.import_now()

--- a/src/diffpy/srreal/tests/testdebyepdfcalculator.py
+++ b/src/diffpy/srreal/tests/testdebyepdfcalculator.py
@@ -160,6 +160,7 @@ class TestDebyePDFCalculator(unittest.TestCase):
         dpdfc.delta2 = 0.3
         dpdfc.maxextension = 10.1
         dpdfc.qbroad = 0.01
+        dpdfc.qbroad_new = 0.01
         dpdfc.qdamp = 0.05
         dpdfc.qmax = 10
         dpdfc.qmin = 0.5

--- a/src/diffpy/srreal/tests/testpdfcalculator.py
+++ b/src/diffpy/srreal/tests/testpdfcalculator.py
@@ -252,6 +252,7 @@ class TestPDFCalculator(unittest.TestCase):
         pdfc.maxextension = 10.1
         pdfc.peakprecision = 5e-06
         pdfc.qbroad = 0.01
+        pdfc.qbroad_new = 0.01
         pdfc.qdamp = 0.05
         pdfc.qmax = 10
         pdfc.qmin = 0.5

--- a/src/diffpy/srreal/tests/testpeakwidthmodel.py
+++ b/src/diffpy/srreal/tests/testpeakwidthmodel.py
@@ -214,6 +214,7 @@ class TestJeongPeakWidth(unittest.TestCase):
         self.assertTrue(hasattr(self.pwm, 'delta1'))
         self.assertTrue(hasattr(self.pwm, 'delta2'))
         self.assertTrue(hasattr(self.pwm, 'qbroad'))
+        self.assertTrue(hasattr(self.pwm, 'qbroad_new'))
         return
 
 
@@ -224,11 +225,13 @@ class TestJeongPeakWidth(unittest.TestCase):
         pwm.delta1 = 1
         pwm.delta2 = 2
         pwm.qbroad = 3
+        pwm.qbroad_new = 4
         pwm2 = pickle.loads(pickle.dumps(pwm))
         self.assertEqual(JeongPeakWidth, type(pwm2))
         self.assertEqual(1, pwm2.delta1)
         self.assertEqual(2, pwm2.delta2)
         self.assertEqual(3, pwm2.qbroad)
+        self.assertEqual(4, pwm2.qbroad_new)
         return
 
 # ----------------------------------------------------------------------------

--- a/src/extensions/wrap_PeakWidthModel.cpp
+++ b/src/extensions/wrap_PeakWidthModel.cpp
@@ -93,7 +93,8 @@ const char* doc_JeongPeakWidth = "\
 Calculate PDF peak width assuming I.-K. Jeong model of correlated motion.\n\
 This returns mean-square displacement of atoms in the pair along their\n\
 bond corrected for correlated motion and data noise at high-Q by a scaling\n\
-factor  sqrt(1 - delta1/r - delta2/r**2 + (qbroad * r)**2).\n\
+and additive factor  \n\
+sqrt(1 - delta1/r - delta2/r**2 + (qbroad * r)**2) + (qbroad_new * r)**2.\n\
 ";
 
 const char* doc_PeakWidthModelOwner = "\


### PR DESCRIPTION
This modifies the pdfcalculators to take advantage of the Q_broad_new parameters in the JeongPeakWidth of libdiffpy.

relates to
https://github.com/diffpy/libdiffpy/issues/29
and
https://github.com/diffpy/libdiffpy/pull/30

@pavoljuhas @sbillinge  Ready for review