### PR TITLE
Fix at-exit cleanup to avoid the GIL error

### DIFF
--- a/src/diffpy/srreal/_cleanup.py
+++ b/src/diffpy/srreal/_cleanup.py
@@ -27,6 +27,7 @@ a call of _registerThisType.
 """
 
 
+import atexit
 import weakref
 
 
@@ -62,7 +63,7 @@ class _DerivedClassesCleanUpHandler(object):
         return
 
 
-    def __del__(self):
+    def clean(self):
         while self._references:
             wr = self._references.pop()
             obj = wr()
@@ -75,7 +76,8 @@ class _DerivedClassesCleanUpHandler(object):
 
 # create singleton instance of the cleanup handler
 _cleanup_handler = _DerivedClassesCleanUpHandler()
-del _DerivedClassesCleanUpHandler
+atexit.register(_cleanup_handler.clean)
 
+del _DerivedClassesCleanUpHandler
 
 # End of file.

--- a/src/diffpy/srreal/tests/testpairquantity.py
+++ b/src/diffpy/srreal/tests/testpairquantity.py
@@ -83,7 +83,7 @@ class TestPairQuantity(unittest.TestCase):
         spm = self.pq.setPairMask
         gpm = self.pq.getPairMask
         self.assertRaises(TypeError, spm, 0.0, 0, False)
-        self.assertRaises(TypeError, spm, numpy.complex(0.5), 0, False)
+        self.assertRaises(TypeError, spm, complex(0.5), 0, False)
         self.assertTrue(gpm(0, 0))
         spm(numpy.int32(1), 0, True, others=False)
         self.assertTrue(gpm(0, 1))


### PR DESCRIPTION
Use atexit for cleanup of Python-extended prototypes

Use standard atexit handler to remove Python-extended prototype
objects from C++ registry.  Ensure cleanup is truly executed
instead of relying on garbage collector to call `__del__`.

This prevents the following error message on Python exit

    Fatal Python error: PyThreadState_Get: the function must be called
    with the GIL held, but the GIL is released (the current Python
    thread state is NULL)
