### PR TITLE
fix: complete dependencies

### DIFF
--- a/requirements/build.txt
+++ b/requirements/build.txt
@@ -1,3 +1,4 @@
 python
 boost
 numpy
+# libobjcryst (if libdiffpy built with objcryst)

--- a/requirements/conda.txt
+++ b/requirements/conda.txt
@@ -3,4 +3,6 @@ numpy
 libdiffpy
 setuptools
 diffpy.structure
-periodictable
+gsl
+# periodictable
+# pyobjcryst (up to py3.11 for mac)


### PR DESCRIPTION
@sbillinge This still needs some discussion.

`objcryst` support will not be activated if `libdiffpy` isn't complied with `libobjcryst`, but if `libdiffpy` is complied with `libobjcryst` then `libobjcryst` (and of course `libdiffpy`) will also be a *build* dependency of `diffpy.srreal`. `pyobjcryst` is also needed for `diffpy.srreal` (built with `libobjcryst`), which has weird conda install conflicts for me even if it's up to py3.13. It can be installed for py3.11.

`periodictable` is a pure python optional *run* dependency.

