### PR TITLE
CI: set up GitHub reusable workflows with Python 3.13 support.

### DIFF
--- a/.github/workflows/matrix-and-codecov-on-merge-to-main.yml
+++ b/.github/workflows/matrix-and-codecov-on-merge-to-main.yml
@@ -1,6 +1,7 @@
 name: CI
 
 on:
+  pull_request:
   push:
     branches:
       - main

--- a/.github/workflows/tests-on-pr.yml
+++ b/.github/workflows/tests-on-pr.yml
@@ -26,7 +26,7 @@ jobs:
           auto-update-conda: true
           environment-file: environment.yml
           auto-activate-base: false
-          python-version: 3.12
+          python-version: 3.13
 
       - name: Conda config
         run: >-

--- a/.github/workflows/tests-on-pr.yml
+++ b/.github/workflows/tests-on-pr.yml
@@ -4,40 +4,15 @@ on:
   push:
     branches:
       - main
-      - cookie
   pull_request:
   workflow_dispatch:
 
 jobs:
   validate:
-    defaults:
-      run:
-        shell: bash -l {0}
-
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check out diffpy.srreal
-        uses: actions/checkout@v4
-
-      - name: Initialize miniconda
-        uses: conda-incubator/setup-miniconda@v3
-        with:
-          activate-environment: test
-          auto-update-conda: true
-          environment-file: environment.yml
-          auto-activate-base: false
-          python-version: 3.13
-
-      - name: Conda config
-        run: >-
-          conda config --set always_yes yes
-          --set changeps1 no
-
-      - name: Install diffpy.srreal and requirements
-        run: |
-          conda install --file requirements/test.txt
-          conda install boost numpy libdiffpy setuptools diffpy.structure periodictable gsl
-          python -m pip install . --no-deps
-
-      - name: Validate diffpy.pdfgui
-        run: pytest tests
+    uses: Billingegroup/release-scripts/.github/workflows/_tests-on-pr.yml@v0
+    with:
+      project: diffpy.srreal
+      c_extension: true
+      headless: false
+    secrets:
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/news/workflow-reuse.rst
+++ b/news/workflow-reuse.rst
@@ -1,6 +1,6 @@
 **Added:**
 
-* Set up for GitHub reuseable workflows with Python 3.13 support.
+* Set up GitHub reusable workflows with Python 3.13 support.
 
 **Changed:**
 

--- a/news/workflow-reuse.rst
+++ b/news/workflow-reuse.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* Set up for GitHub reuseable workflows with Python 3.13 support.
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>


### PR DESCRIPTION
Currently draft mode: 

Once `libdiffpy ` supports Windows (conda), we can re-run this CI. 

https://github.com/diffpy/diffpy.srreal/issues/51