### PR TITLE
skpkg: pre-commit auto fixes with line length of 79

### DIFF
--- a/doc/source/examples/distanceprinter.py
+++ b/doc/source/examples/distanceprinter.py
@@ -1,15 +1,15 @@
 #!/usr/bin/env python
 
-"""Demonstration of using PairQuantity class for a printout of pair distances
-in periodic and non-periodic structures."""
+"""Demonstration of using PairQuantity class for a printout of pair
+distances in periodic and non-periodic structures."""
 
 from diffpy.srreal.pairquantity import PairQuantity
 from diffpy.structure import Structure
 
 
 class DistancePrinter(PairQuantity):
-    """This PairQuantity class simply prints the visited pair distances and the
-    indices of the contributing atoms."""
+    """This PairQuantity class simply prints the visited pair distances
+    and the indices of the contributing atoms."""
 
     def _resetValue(self):
         self.count = 0

--- a/doc/source/examples/distanceprinter.py
+++ b/doc/source/examples/distanceprinter.py
@@ -16,7 +16,10 @@ class DistancePrinter(PairQuantity):
 
     def _addPairContribution(self, bnds, sumscale):
         self.count += bnds.multiplicity() * sumscale / 2.0
-        print("%i %g %i %i" % (self.count, bnds.distance(), bnds.site0(), bnds.site1()))
+        print(
+            "%i %g %i %i"
+            % (self.count, bnds.distance(), bnds.site0(), bnds.site1())
+        )
         return
 
 

--- a/doc/source/examples/lennardjones/ljcalculator.py
+++ b/doc/source/examples/lennardjones/ljcalculator.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
-"""Demonstration of using PairQuantity class for calculation of Lennard Jones
-potential.
+"""Demonstration of using PairQuantity class for calculation of Lennard
+Jones potential.
 
 Vij = 4 * ( rij ** -12  -  rij ** -6 )
 """

--- a/doc/source/examples/parallelPDF.py
+++ b/doc/source/examples/parallelPDF.py
@@ -25,7 +25,11 @@ Uisodefault = 0.005
 
 # configure options parsing
 parser = optparse.OptionParser("%prog [options]\n" + __doc__)
-parser.add_option("--pyobjcryst", action="store_true", help="Use pyobjcryst to load the CIF file.")
+parser.add_option(
+    "--pyobjcryst",
+    action="store_true",
+    help="Use pyobjcryst to load the CIF file.",
+)
 parser.allow_interspersed_args = True
 opts, args = parser.parse_args(sys.argv[1:])
 

--- a/doc/source/examples/parallelPDF.py
+++ b/doc/source/examples/parallelPDF.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 
-"""Demonstration of parallel PDF calculation using the multiprocessing package.
+"""Demonstration of parallel PDF calculation using the multiprocessing
+package.
 
 A PDF of menthol structure is first calculated on a single core and then
 on all computer CPUs.  The script then compares both results and prints

--- a/news/pc-blackv2.rst
+++ b/news/pc-blackv2.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* Configure ``black`` to have a linelength requirement of 79 characters.
+
+**Security:**
+
+* <news item>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,3 +78,8 @@ exclude = '''
   | tests/data
 )/
 '''
+
+[tool.docformatter]
+recursive = true
+wrap-summaries = 72
+wrap-descriptions = 72

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,7 @@ ignore-words = ".codespell/ignore_words.txt"
 skip = "*.cif,*.dat"
 
 [tool.black]
-line-length = 115
+line-length = 79
 include = '\.pyi?$'
 exclude = '''
 /(

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,8 @@ def get_boost_config():
         conda_prefix = os.environ.get("CONDA_PREFIX")
         if not conda_prefix:
             raise EnvironmentError(
-                "Neither BOOST_PATH nor CONDA_PREFIX are set. " "Please install Boost or set BOOST_PATH."
+                "Neither BOOST_PATH nor CONDA_PREFIX are set. "
+                "Please install Boost or set BOOST_PATH."
             )
         if os.name == "nt":
             inc = Path(conda_prefix) / "Library" / "include"
@@ -99,7 +100,11 @@ ext_kws = {
 
 def create_extensions():
     "Initialize Extension objects for the setup function."
-    ext = Extension("diffpy.srreal.srreal_ext", glob.glob("src/extensions/*.cpp"), **ext_kws)
+    ext = Extension(
+        "diffpy.srreal.srreal_ext",
+        glob.glob("src/extensions/*.cpp"),
+        **ext_kws,
+    )
     return [ext]
 
 

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,8 @@ def get_objcryst_libraries():
     conda_prefix = os.environ.get("CONDA_PREFIX")
     if not conda_prefix:
         raise EnvironmentError(
-            "CONDA_PREFIX is not set. Please install ObjCryst using conda and activate the environment."
+            "CONDA_PREFIX is not set. "
+            "Please install ObjCryst using conda and activate the environment."
         )
     if os.name == "nt":
         libdir = Path(conda_prefix) / "Library" / "lib"
@@ -65,7 +66,8 @@ def get_objcryst_libraries():
         stem = Path(fn).stem
         if "objcryst" not in stem.lower():
             continue
-        # strip a leading "lib" so that setuptools does -lObjCryst, not -llibObjCryst
+        # strip a leading "lib"
+        # so that setuptools does -lObjCryst, not -llibObjCryst
         if os.name != "nt" and stem.startswith("lib"):
             stem = stem[3:]
         libs.append(stem)

--- a/src/diffpy/srreal/_docstrings.py
+++ b/src/diffpy/srreal/_docstrings.py
@@ -18,7 +18,8 @@
 
 
 def get_registry_docstrings(cls):
-    """Build a dictionary of docstrings per each HasClassRegistry method.
+    """Build a dictionary of docstrings per each HasClassRegistry
+    method.
 
     Parameters
     ----------

--- a/src/diffpy/srreal/_final_imports.py
+++ b/src/diffpy/srreal/_final_imports.py
@@ -25,7 +25,8 @@ This avoids unresolvable import dependencies for any order of imports.
 
 
 def import_now():
-    """Import all Python modules that tweak extension-defined classes."""
+    """Import all Python modules that tweak extension-defined
+    classes."""
     global _import_now_called
     if _import_now_called:
         return

--- a/src/diffpy/srreal/atomradiitable.py
+++ b/src/diffpy/srreal/atomradiitable.py
@@ -63,9 +63,9 @@ class CovalentRadiiTable(AtomRadiiTable):
         return copy.copy(self)
 
     def type(self):
-        """Unique string identifier of the CovalentRadiiTable type. This is
-        used for class registration and as an argument for the createByType
-        function.
+        """Unique string identifier of the CovalentRadiiTable type. This
+        is used for class registration and as an argument for the
+        createByType function.
 
         Return string.
         """

--- a/src/diffpy/srreal/attributes.py
+++ b/src/diffpy/srreal/attributes.py
@@ -36,7 +36,8 @@ Attributes.__getattr__ = _getattr
 
 
 def _setattr(self, name, value):
-    """Assign to C++ double attribute if Python attribute does not exist."""
+    """Assign to C++ double attribute if Python attribute does not
+    exist."""
     try:
         object.__getattribute__(self, name)
     except AttributeError:

--- a/src/diffpy/srreal/bondcalculator.py
+++ b/src/diffpy/srreal/bondcalculator.py
@@ -43,8 +43,8 @@ BondCalculator.rmax = propertyFromExtDoubleAttr(
 
 
 def _init_kwargs(self, **kwargs):
-    """Create a new instance of BondCalculator. Keyword arguments can be used
-    to configure calculator properties, for example:
+    """Create a new instance of BondCalculator. Keyword arguments can be
+    used to configure calculator properties, for example:
 
     bdc = BondCalculator(rmin=1.5, rmax=2.5)
 

--- a/src/diffpy/srreal/devutils/tunePeakPrecision.py
+++ b/src/diffpy/srreal/devutils/tunePeakPrecision.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
-"""Tune the peak precision parameter so that PDFCalculator gives equivalent
-results to diffpy.pdffit2.
+"""Tune the peak precision parameter so that PDFCalculator gives
+equivalent results to diffpy.pdffit2.
 
 Usage: tunePeakPrecision.py [qmax] [peakprecision] [createplot]
 """

--- a/src/diffpy/srreal/devutils/tunePeakPrecision.py
+++ b/src/diffpy/srreal/devutils/tunePeakPrecision.py
@@ -108,7 +108,9 @@ def comparePDFCalculators(qmax, peakprecision=None):
     rv = {}
     rv["qmax"] = qmax
     rv["peakprecision"] = (
-        peakprecision is None and PDFCalculator()._getDoubleAttr("peakprecision") or peakprecision
+        peakprecision is None
+        and PDFCalculator()._getDoubleAttr("peakprecision")
+        or peakprecision
     )
     ttic = time.clock()
     rg0 = Gpdffit2(qmax)
@@ -175,7 +177,10 @@ def main():
     processCommandLineArguments()
     cmpdata = comparePDFCalculators(qmax, peakprecision)
     print(
-        ("qmax = %(qmax)g  pkprec = %(peakprecision)g  " + "grmsd = %(grmsd)g  t0 = %(t0).3f  t1 = %(t1).3f")
+        (
+            "qmax = %(qmax)g  pkprec = %(peakprecision)g  "
+            + "grmsd = %(grmsd)g  t0 = %(t0).3f  t1 = %(t1).3f"
+        )
         % cmpdata
     )
     if createplot:

--- a/src/diffpy/srreal/eventticker.py
+++ b/src/diffpy/srreal/eventticker.py
@@ -12,7 +12,8 @@
 # See LICENSE.txt for license information.
 #
 ##############################################################################
-"""Class EventTicker -- storage of modification times of dependent objects."""
+"""Class EventTicker -- storage of modification times of dependent
+objects."""
 
 
 # exported items

--- a/src/diffpy/srreal/overlapcalculator.py
+++ b/src/diffpy/srreal/overlapcalculator.py
@@ -12,7 +12,8 @@
 # See LICENSE_DANSE.txt for license information.
 #
 ##############################################################################
-"""Class OverlapCalculator -- calculator of atom overlaps in a structure."""
+"""Class OverlapCalculator -- calculator of atom overlaps in a
+structure."""
 
 
 # exported items, these also makes them show in pydoc.
@@ -50,8 +51,8 @@ OverlapCalculator.rmaxused = propertyFromExtDoubleAttr(
 
 
 def _init_kwargs(self, **kwargs):
-    """Create a new instance of OverlapCalculator. Keyword arguments can be
-    used to configure calculator properties, for example:
+    """Create a new instance of OverlapCalculator. Keyword arguments can
+    be used to configure calculator properties, for example:
 
     olc = OverlapCalculator(rmax=2.5)
 

--- a/src/diffpy/srreal/pairquantity.py
+++ b/src/diffpy/srreal/pairquantity.py
@@ -12,7 +12,8 @@
 # See LICENSE_DANSE.txt for license information.
 #
 ##############################################################################
-"""Class PairQuantity    -- base class for Python defined calculators."""
+"""Class PairQuantity    -- base class for Python defined
+calculators."""
 
 
 # exported items

--- a/src/diffpy/srreal/parallel.py
+++ b/src/diffpy/srreal/parallel.py
@@ -43,8 +43,8 @@ def createParallelCalculator(pqobj, ncpu, pmap):
     """
 
     class ParallelPairQuantity(Attributes):
-        """Class for running parallel calculations.  This is a proxy class to
-        the wrapper PairQuantity type with the same interface.
+        """Class for running parallel calculations.  This is a proxy
+        class to the wrapper PairQuantity type with the same interface.
 
         Instance data:
 
@@ -70,7 +70,8 @@ def createParallelCalculator(pqobj, ncpu, pmap):
             return
 
         def eval(self, stru=None):
-            """Perform parallel calculation and return internal value array.
+            """Perform parallel calculation and return internal value
+            array.
 
             stru -- object that can be converted to StructureAdapter,
                     e.g., example diffpy Structure or pyobjcryst Crystal.
@@ -208,7 +209,8 @@ def createParallelCalculator(pqobj, ncpu, pmap):
 
 
 def _parallelData(kwd):
-    """Helper for calculating and fetching raw results from a worker node."""
+    """Helper for calculating and fetching raw results from a worker
+    node."""
     pqobj = kwd["pqobj"]
     pqobj._setupParallelRun(kwd["cpuindex"], kwd["ncpu"])
     pqobj.eval()

--- a/src/diffpy/srreal/parallel.py
+++ b/src/diffpy/srreal/parallel.py
@@ -163,7 +163,9 @@ def createParallelCalculator(pqobj, ncpu, pmap):
         return proxymethod
 
     for n, f in inspect.getmembers(pqtype, inspect.isroutine):
-        ignore = n not in proxy_forced and (n.startswith("_") or hasattr(ParallelPairQuantity, n))
+        ignore = n not in proxy_forced and (
+            n.startswith("_") or hasattr(ParallelPairQuantity, n)
+        )
         if ignore:
             continue
         setattr(ParallelPairQuantity, n, _make_proxymethod(n, f))

--- a/src/diffpy/srreal/pdfbaseline.py
+++ b/src/diffpy/srreal/pdfbaseline.py
@@ -48,8 +48,9 @@ LinearBaseline.slope = propertyFromExtDoubleAttr(
 
 
 def makePDFBaseline(name, fnc, replace=False, **dbattrs):
-    """Helper function for registering Python function as a PDFBaseline. This
-    is required for using Python function as PDFCalculator.baseline.
+    """Helper function for registering Python function as a PDFBaseline.
+    This is required for using Python function as
+    PDFCalculator.baseline.
 
     name     -- unique string name for registering Python function in the
                 global registry of PDFBaseline types.  This will be the

--- a/src/diffpy/srreal/pdfbaseline.py
+++ b/src/diffpy/srreal/pdfbaseline.py
@@ -85,7 +85,9 @@ def makePDFBaseline(name, fnc, replace=False, **dbattrs):
     """
     from diffpy.srreal.wraputils import _wrapAsRegisteredUnaryFunction
 
-    rv = _wrapAsRegisteredUnaryFunction(PDFBaseline, name, fnc, replace=replace, **dbattrs)
+    rv = _wrapAsRegisteredUnaryFunction(
+        PDFBaseline, name, fnc, replace=replace, **dbattrs
+    )
     return rv
 
 

--- a/src/diffpy/srreal/pdfcalculator.py
+++ b/src/diffpy/srreal/pdfcalculator.py
@@ -86,7 +86,8 @@ assert all(
 
 
 def _defineCommonInterface(cls):
-    """This function defines shared properties of PDF calculator classes."""
+    """This function defines shared properties of PDF calculator
+    classes."""
 
     cls.scale = propertyFromExtDoubleAttr(
         "scale",
@@ -161,10 +162,10 @@ def _defineCommonInterface(cls):
     )
 
     def _call_kwargs(self, structure=None, **kwargs):
-        """Calculate PDF for the given structure as an (r, G) tuple. Keyword
-        arguments can be used to configure calculator attributes, these
-        override any properties that may be passed from the structure, such as
-        spdiameter.
+        """Calculate PDF for the given structure as an (r, G) tuple.
+        Keyword arguments can be used to configure calculator
+        attributes, these override any properties that may be passed
+        from the structure, such as spdiameter.
 
         structure    -- a structure object to be evaluated.  Reuse the last
                         structure when None.

--- a/src/diffpy/srreal/pdfenvelope.py
+++ b/src/diffpy/srreal/pdfenvelope.py
@@ -115,7 +115,9 @@ def makePDFEnvelope(name, fnc, replace=False, **dbattrs):
     """
     from diffpy.srreal.wraputils import _wrapAsRegisteredUnaryFunction
 
-    rv = _wrapAsRegisteredUnaryFunction(PDFEnvelope, name, fnc, replace=replace, **dbattrs)
+    rv = _wrapAsRegisteredUnaryFunction(
+        PDFEnvelope, name, fnc, replace=replace, **dbattrs
+    )
     return rv
 
 

--- a/src/diffpy/srreal/pdfenvelope.py
+++ b/src/diffpy/srreal/pdfenvelope.py
@@ -77,8 +77,9 @@ StepCutEnvelope.stepcut = propertyFromExtDoubleAttr(
 
 
 def makePDFEnvelope(name, fnc, replace=False, **dbattrs):
-    """Helper function for registering Python function as a PDFEnvelope. This
-    is required for using Python function as PDFCalculator envelope.
+    """Helper function for registering Python function as a PDFEnvelope.
+    This is required for using Python function as PDFCalculator
+    envelope.
 
     name     -- unique string name for registering Python function in the
                 global registry of PDFEnvelope types.  This will be the

--- a/src/diffpy/srreal/peakwidthmodel.py
+++ b/src/diffpy/srreal/peakwidthmodel.py
@@ -20,7 +20,12 @@ Classes for configuring peak width evaluation in PDF calculations:
 
 
 # exported items
-__all__ = ["PeakWidthModel", "ConstantPeakWidth", "DebyeWallerPeakWidth", "JeongPeakWidth"]
+__all__ = [
+    "PeakWidthModel",
+    "ConstantPeakWidth",
+    "DebyeWallerPeakWidth",
+    "JeongPeakWidth",
+]
 
 from diffpy.srreal import _final_imports
 from diffpy.srreal.srreal_ext import (

--- a/src/diffpy/srreal/scatteringfactortable.py
+++ b/src/diffpy/srreal/scatteringfactortable.py
@@ -17,7 +17,14 @@ isotopes."""
 
 
 # exported items, these also makes them show in pydoc.
-__all__ = ["ScatteringFactorTable", "SFTXray", "SFTElectron", "SFTNeutron", "SFTElectronNumber", "SFAverage"]
+__all__ = [
+    "ScatteringFactorTable",
+    "SFTXray",
+    "SFTElectron",
+    "SFTNeutron",
+    "SFTElectronNumber",
+    "SFAverage",
+]
 
 from diffpy.srreal.sfaverage import SFAverage
 from diffpy.srreal.srreal_ext import (

--- a/src/diffpy/srreal/sfaverage.py
+++ b/src/diffpy/srreal/sfaverage.py
@@ -150,7 +150,11 @@ class SFAverage(object):
         sfa.f1sum = 0.0 * q
         sfa.f2sum = 0.0 * q
         # resolve the lookup table object `tb`
-        tb = sftb if not isinstance(sftb, str) else ScatteringFactorTable.createByType(sftb)
+        tb = (
+            sftb
+            if not isinstance(sftb, str)
+            else ScatteringFactorTable.createByType(sftb)
+        )
         for smbl, cnt in sfa.composition.items():
             sfq = tb.lookup(smbl, q)
             sfa.f1sum += cnt * sfq

--- a/src/diffpy/srreal/sfaverage.py
+++ b/src/diffpy/srreal/sfaverage.py
@@ -116,7 +116,8 @@ class SFAverage(object):
 
     @classmethod
     def fromComposition(cls, composition, sftb, q=0):
-        """Calculate average scattering factors from atom concentrations.
+        """Calculate average scattering factors from atom
+        concentrations.
 
         Parameters
         ----------

--- a/src/diffpy/srreal/structureadapter.py
+++ b/src/diffpy/srreal/structureadapter.py
@@ -12,8 +12,8 @@
 # See LICENSE_DANSE.txt for license information.
 #
 ##############################################################################
-"""Class StructureAdapter -- adapter of any structure object to the interface
-expected by srreal PairQuantity calculators.
+"""Class StructureAdapter -- adapter of any structure object to the
+interface expected by srreal PairQuantity calculators.
 
 Routines:
 
@@ -73,11 +73,11 @@ def createStructureAdapter(stru):
 
 
 def RegisterStructureAdapter(fqname, fnc=None):
-    """Function decorator that marks it as a converter of specified object type
-    to StructureAdapter class in diffpy.srreal.  The registered structure
-    object types can be afterwards directly used with calculators in
-    diffpy.srreal as they would be implicitly converted to the internal
-    diffpy.srreal structure type.
+    """Function decorator that marks it as a converter of specified
+    object type to StructureAdapter class in diffpy.srreal.  The
+    registered structure object types can be afterwards directly used
+    with calculators in diffpy.srreal as they would be implicitly
+    converted to the internal diffpy.srreal structure type.
 
     fqname   -- fully qualified class name for the convertible objects.
                 This is the quoted string included in "str(type(obj))".

--- a/src/diffpy/srreal/structureconverters.py
+++ b/src/diffpy/srreal/structureconverters.py
@@ -26,8 +26,12 @@ from diffpy.srreal.structureadapter import RegisterStructureAdapter
 # Converters for Molecule and Crystal from pyobjcryst ------------------------
 
 
-RegisterStructureAdapter("pyobjcryst._pyobjcryst.Molecule", convertObjCrystMolecule)
-RegisterStructureAdapter("pyobjcryst._pyobjcryst.Crystal", convertObjCrystCrystal)
+RegisterStructureAdapter(
+    "pyobjcryst._pyobjcryst.Molecule", convertObjCrystMolecule
+)
+RegisterStructureAdapter(
+    "pyobjcryst._pyobjcryst.Crystal", convertObjCrystCrystal
+)
 
 # Converter for Structure class from diffpy.structure ------------------------
 
@@ -115,11 +119,15 @@ class _DiffPyStructureMetadata(object):
 # end of class _DiffPyStructureMetadata
 
 
-class DiffPyStructureAtomicAdapter(_DiffPyStructureMetadata, AtomicStructureAdapter):
+class DiffPyStructureAtomicAdapter(
+    _DiffPyStructureMetadata, AtomicStructureAdapter
+):
     pass
 
 
-class DiffPyStructurePeriodicAdapter(_DiffPyStructureMetadata, PeriodicStructureAdapter):
+class DiffPyStructurePeriodicAdapter(
+    _DiffPyStructureMetadata, PeriodicStructureAdapter
+):
     pass
 
 

--- a/src/diffpy/srreal/structureconverters.py
+++ b/src/diffpy/srreal/structureconverters.py
@@ -12,8 +12,8 @@
 # See LICENSE.txt for license information.
 #
 ##############################################################################
-"""Converters from other structure representations in Python to diffpy.srreal
-StructureAdapter classes."""
+"""Converters from other structure representations in Python to
+diffpy.srreal StructureAdapter classes."""
 
 from diffpy.srreal.srreal_ext import (
     AtomicStructureAdapter,
@@ -69,12 +69,14 @@ class _DiffPyStructureMetadata(object):
 
     @staticmethod
     def hasMetadata(stru):
-        """True if Structure object carries data in its pdffit attribute."""
+        """True if Structure object carries data in its pdffit
+        attribute."""
         rv = hasattr(stru, "pdffit") and bool(stru.pdffit)
         return rv
 
     def _customPQConfig(self, pqobj):
-        """Apply PDF-related metadata if defined in PDFFit structure format."""
+        """Apply PDF-related metadata if defined in PDFFit structure
+        format."""
         pqname = type(pqobj).__name__
         if pqname not in ("PDFCalculator", "DebyePDFCalculator"):
             return
@@ -102,7 +104,8 @@ class _DiffPyStructureMetadata(object):
         return
 
     def _fetchMetadata(self, stru):
-        """Copy data from the pdffit attribute of diffpy Structure object.
+        """Copy data from the pdffit attribute of diffpy Structure
+        object.
 
         stru -- instance of Structure class from diffpy.structure
 

--- a/src/diffpy/srreal/wraputils.py
+++ b/src/diffpy/srreal/wraputils.py
@@ -59,7 +59,9 @@ def setattrFromKeywordArguments(obj, **kwargs):
     return
 
 
-def _wrapAsRegisteredUnaryFunction(cls, regname, fnc, replace=False, **dbattrs):
+def _wrapAsRegisteredUnaryFunction(
+    cls, regname, fnc, replace=False, **dbattrs
+):
     """Helper function for wrapping Python function as PDFBaseline or
     PDFEnvelope functor.  Not intended for direct usage, this function is
     rather called from makePDFBaseline or makePDFEnvelope wrappers.
@@ -149,7 +151,9 @@ def _pickle_getstate(self):
 
 def _pickle_setstate(self, state):
     if len(state) != 1:
-        emsg = "expected 1-item tuple in call to __setstate__, got " + repr(state)
+        emsg = "expected 1-item tuple in call to __setstate__, got " + repr(
+            state
+        )
         raise ValueError(emsg)
     self.__dict__.update(state[0])
     return

--- a/src/diffpy/srreal/wraputils.py
+++ b/src/diffpy/srreal/wraputils.py
@@ -12,7 +12,8 @@
 # See LICENSE_DANSE.txt for license information.
 #
 ##############################################################################
-"""Local utilities helpful for tweaking interfaces to boost python classes."""
+"""Local utilities helpful for tweaking interfaces to boost python
+classes."""
 
 
 import copy
@@ -63,8 +64,8 @@ def _wrapAsRegisteredUnaryFunction(
     cls, regname, fnc, replace=False, **dbattrs
 ):
     """Helper function for wrapping Python function as PDFBaseline or
-    PDFEnvelope functor.  Not intended for direct usage, this function is
-    rather called from makePDFBaseline or makePDFEnvelope wrappers.
+    PDFEnvelope functor.  Not intended for direct usage, this function
+    is rather called from makePDFBaseline or makePDFEnvelope wrappers.
 
     cls      -- the functor class for wrapping the Python function
     regname  -- string name for registering the function in the global
@@ -96,9 +97,9 @@ def _wrapAsRegisteredUnaryFunction(
             return copy.copy(self)
 
         def type(self):
-            """Unique string identifier of this functor type.  The string is
-            used for class registration and as an argument for the createByType
-            function.
+            """Unique string identifier of this functor type.  The
+            string is used for class registration and as an argument for
+            the createByType function.
 
             Return string identifier.
             """

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -70,6 +70,8 @@ def has_periodictable():
         del periodictable
     except ImportError:
         has_periodictable = False
-        logging.warning("Cannot import periodictable, periodictable tests skipped.")
+        logging.warning(
+            "Cannot import periodictable, periodictable tests skipped."
+        )
 
     return has_periodictable

--- a/tests/test_bondcalculator.py
+++ b/tests/test_bondcalculator.py
@@ -134,7 +134,10 @@ class TestBondCalculator(unittest.TestCase):
         self.assertEqual(5, numpy.max(bdc.sites0))
         self.assertEqual(0, numpy.min(bdc.sites1))
         self.assertEqual(5, numpy.max(bdc.sites1))
-        dij = [(tuple(d) + (i0, i1)) for d, i0, i1 in zip(bdc.directions, bdc.sites0, bdc.sites1)]
+        dij = [
+            (tuple(d) + (i0, i1))
+            for d, i0, i1 in zip(bdc.directions, bdc.sites0, bdc.sites1)
+        ]
         self.assertEqual(len(dij), len(set(dij)))
         bdc.maskAllPairs(False)
         bdc(self.rutile)
@@ -287,7 +290,10 @@ class TestBondCalculatorObjCryst(unittest.TestCase):
         self.assertEqual(1, numpy.max(bdc.sites0))
         self.assertEqual(0, numpy.min(bdc.sites1))
         self.assertEqual(1, numpy.max(bdc.sites1))
-        dij = [(tuple(d) + (i0, i1)) for d, i0, i1 in zip(bdc.directions, bdc.sites0, bdc.sites1)]
+        dij = [
+            (tuple(d) + (i0, i1))
+            for d, i0, i1 in zip(bdc.directions, bdc.sites0, bdc.sites1)
+        ]
         self.assertEqual(len(dij), len(set(dij)))
         bdc.maskAllPairs(False)
         bdc(self.rutile)

--- a/tests/test_bondcalculator.py
+++ b/tests/test_bondcalculator.py
@@ -79,7 +79,8 @@ class TestBondCalculator(unittest.TestCase):
         return
 
     def test_pickling_derived_structure(self):
-        """Check pickling of BondCalculator with DerivedStructureAdapter."""
+        """Check pickling of BondCalculator with
+        DerivedStructureAdapter."""
         from testutils import DerivedStructureAdapter
 
         bdc = self.bdc

--- a/tests/test_bvscalculator.py
+++ b/tests/test_bvscalculator.py
@@ -139,7 +139,8 @@ class TestBVSCalculator(unittest.TestCase):
         return
 
     def test_pickling_derived_structure(self):
-        """Check pickling of BVSCalculator with DerivedStructureAdapter."""
+        """Check pickling of BVSCalculator with
+        DerivedStructureAdapter."""
         from testutils import DerivedStructureAdapter
 
         bvc = self.bvc

--- a/tests/test_debyepdfcalculator.py
+++ b/tests/test_debyepdfcalculator.py
@@ -23,7 +23,9 @@ class TestDebyePDFCalculator(unittest.TestCase):
         if not TestDebyePDFCalculator.bucky:
             TestDebyePDFCalculator.bucky = loadDiffPyStructure("C60bucky.stru")
         if not TestDebyePDFCalculator.tio2rutile:
-            TestDebyePDFCalculator.tio2rutile = loadDiffPyStructure("TiO2_rutile-fit.stru")
+            TestDebyePDFCalculator.tio2rutile = loadDiffPyStructure(
+                "TiO2_rutile-fit.stru"
+            )
         return
 
     #   def tearDown(self):
@@ -166,7 +168,9 @@ class TestDebyePDFCalculator(unittest.TestCase):
         for a in dpdfc._namesOfDoubleAttributes():
             self.assertEqual(getattr(dpdfc, a), getattr(dpdfc1, a))
         self.assertEqual(13.3, dpdfc1.getEnvelope("sphericalshape").spdiameter)
-        self.assertEqual(dpdfc._namesOfDoubleAttributes(), dpdfc1._namesOfDoubleAttributes())
+        self.assertEqual(
+            dpdfc._namesOfDoubleAttributes(), dpdfc1._namesOfDoubleAttributes()
+        )
         self.assertEqual(dpdfc.usedenvelopetypes, dpdfc1.usedenvelopetypes)
         self.assertRaises(RuntimeError, pickle_with_attr, dpdfc, foo="bar")
         return

--- a/tests/test_overlapcalculator.py
+++ b/tests/test_overlapcalculator.py
@@ -91,7 +91,9 @@ class TestOverlapCalculator(unittest.TestCase):
             self.assertEqual(getattr(olc, a), getattr(olc1, a))
         self.assertFalse(olc1.getPairMask(1, 2))
         self.assertTrue(olc1.getPairMask(0, 0))
-        self.assertTrue(numpy.array_equal(olc.sitesquareoverlaps, olc1.sitesquareoverlaps))
+        self.assertTrue(
+            numpy.array_equal(olc.sitesquareoverlaps, olc1.sitesquareoverlaps)
+        )
         self.assertRaises(RuntimeError, pickle_with_attr, olc, foo="bar")
         return
 
@@ -140,13 +142,18 @@ class TestOverlapCalculator(unittest.TestCase):
         ncpu = 4
         self.pool = multiprocessing.Pool(processes=ncpu)
         olc = self.olc
-        polc = createParallelCalculator(OverlapCalculator(), ncpu, self.pool.imap_unordered)
+        polc = createParallelCalculator(
+            OverlapCalculator(), ncpu, self.pool.imap_unordered
+        )
         olc.atomradiitable.fromString("Ti:1.6, O:0.66")
         polc.atomradiitable = olc.atomradiitable
         self.assertTrue(numpy.array_equal(olc(self.rutile), polc(self.rutile)))
         self.assertTrue(olc.totalsquareoverlap > 0.0)
         self.assertEqual(olc.totalsquareoverlap, polc.totalsquareoverlap)
-        self.assertEqual(sorted(zip(olc.sites0, olc.sites1)), sorted(zip(polc.sites0, polc.sites1)))
+        self.assertEqual(
+            sorted(zip(olc.sites0, olc.sites1)),
+            sorted(zip(polc.sites0, polc.sites1)),
+        )
         olc.atomradiitable.resetAll()
         self.assertEqual(0.0, sum(olc(self.rutile)))
         self.assertEqual(0.0, sum(polc(self.rutile)))
@@ -288,7 +295,9 @@ class TestOverlapCalculator(unittest.TestCase):
         self.assertFalse(numpy.any(olc.coordinations))
         olc.atomradiitable.fromString("Ti:1.6, O:0.66")
         olc(self.rutile)
-        self.assertTrue(numpy.array_equal([8, 8, 3, 3, 3, 3], olc.coordinations))
+        self.assertTrue(
+            numpy.array_equal([8, 8, 3, 3, 3, 3], olc.coordinations)
+        )
         return
 
     def test_coordinationByTypes(self):

--- a/tests/test_overlapcalculator.py
+++ b/tests/test_overlapcalculator.py
@@ -117,7 +117,8 @@ class TestOverlapCalculator(unittest.TestCase):
         return
 
     def test_pickling_derived_structure(self):
-        """Check pickling of OverlapCalculator with DerivedStructureAdapter."""
+        """Check pickling of OverlapCalculator with
+        DerivedStructureAdapter."""
         from testutils import DerivedStructureAdapter
 
         olc = self.olc
@@ -359,7 +360,8 @@ class TestOverlapCalculatorObjCryst(unittest.TestCase):
         return
 
     def test_totalsquareoverlap(self):
-        """Check OverlapCalculator.totalsquareoverlap for ObjCryst crystal."""
+        """Check OverlapCalculator.totalsquareoverlap for ObjCryst
+        crystal."""
         olc = self.olc
         self.assertEqual(0.0, olc.totalsquareoverlap)
         olc(self.rutile)
@@ -370,7 +372,8 @@ class TestOverlapCalculatorObjCryst(unittest.TestCase):
         return
 
     def test_meansquareoverlap(self):
-        """Check OverlapCalculator.meansquareoverlap for ObjCryst crystal."""
+        """Check OverlapCalculator.meansquareoverlap for ObjCryst
+        crystal."""
         olc = self.olc
         self.assertEqual(0.0, olc.meansquareoverlap)
         olc(self.rutile)
@@ -381,7 +384,8 @@ class TestOverlapCalculatorObjCryst(unittest.TestCase):
         return
 
     def test_flipDiffTotal(self):
-        """Check OverlapCalculator.flipDiffTotal for an ObjCryst crystal."""
+        """Check OverlapCalculator.flipDiffTotal for an ObjCryst
+        crystal."""
         olc = self.olc
         olc(self.rutile)
         self.assertEqual(0.0, olc.flipDiffTotal(0, 1))
@@ -396,7 +400,8 @@ class TestOverlapCalculatorObjCryst(unittest.TestCase):
         return
 
     def test_flipDiffMean(self):
-        """Check OverlapCalculator.flipDiffMean for an ObjCryst crystal."""
+        """Check OverlapCalculator.flipDiffMean for an ObjCryst
+        crystal."""
         olc = self.olc
         olc(self.rutile)
         self.assertEqual(0.0, olc.flipDiffMean(0, 1))
@@ -414,7 +419,8 @@ class TestOverlapCalculatorObjCryst(unittest.TestCase):
         return
 
     def test_getNeighborSites(self):
-        """Check OverlapCalculator.getNeighborSites for an ObjCryst crystal."""
+        """Check OverlapCalculator.getNeighborSites for an ObjCryst
+        crystal."""
         olc = self.olc
         olc(self.rutile)
         self.assertEqual(set(), olc.getNeighborSites(0))
@@ -426,7 +432,8 @@ class TestOverlapCalculatorObjCryst(unittest.TestCase):
         return
 
     def test_coordinations(self):
-        """Check OverlapCalculator.coordinations for an ObjCryst crystal."""
+        """Check OverlapCalculator.coordinations for an ObjCryst
+        crystal."""
         olc = self.olc
         self.assertEqual(0, len(olc.coordinations))
         olc(self.rutile)
@@ -453,7 +460,8 @@ class TestOverlapCalculatorObjCryst(unittest.TestCase):
         return
 
     def test_neighborhoods(self):
-        """Check OverlapCalculator.neighborhoods for an ObjCryst crystal."""
+        """Check OverlapCalculator.neighborhoods for an ObjCryst
+        crystal."""
         olc = self.olc
         self.assertEqual([], olc.neighborhoods)
         olc(self.rutile)

--- a/tests/test_pairquantity.py
+++ b/tests/test_pairquantity.py
@@ -128,7 +128,8 @@ class TestPairQuantity(unittest.TestCase):
         return
 
     def test__addPairContribution(self):
-        """Check Python override of PairQuantity._addPairContribution."""
+        """Check Python override of
+        PairQuantity._addPairContribution."""
         pqcnt = PQCounter()
         self.assertEqual(0, pqcnt(carbonzchain(0)))
         self.assertEqual(0, pqcnt(carbonzchain(1)))
@@ -137,7 +138,8 @@ class TestPairQuantity(unittest.TestCase):
         return
 
     def test_optimized_evaluation(self):
-        """Check OPTIMIZED evaluation in Python-defined calculator class."""
+        """Check OPTIMIZED evaluation in Python-defined calculator
+        class."""
         c8 = carbonzchain(8)
         c9 = carbonzchain(9)
         pqd = PQDerived()

--- a/tests/test_parallel.py
+++ b/tests/test_parallel.py
@@ -54,7 +54,9 @@ class TestRoutines(unittest.TestCase):
         self.assertEqual("BASIC", ppdfc.evaluatortype)
         self.assertEqual("BASIC", pdfc.evaluatortype)
         ppdfc.evaluatortype = "BASIC"
-        self.assertRaises(ValueError, setattr, ppdfc, "evaluatortype", "OPTIMIZED")
+        self.assertRaises(
+            ValueError, setattr, ppdfc, "evaluatortype", "OPTIMIZED"
+        )
         return
 
     def test_parallel_pdf(self):
@@ -67,7 +69,9 @@ class TestRoutines(unittest.TestCase):
         r1, g1 = ppdfc1(self.cdse)
         self.assertTrue(numpy.array_equal(r0, r1))
         self.assertTrue(numpy.allclose(g0, g1))
-        ppdfc2 = createParallelCalculator(PDFCalculator(), self.ncpu, self.pool.imap_unordered)
+        ppdfc2 = createParallelCalculator(
+            PDFCalculator(), self.ncpu, self.pool.imap_unordered
+        )
         r2, g2 = ppdfc2(self.cdse)
         self.assertTrue(numpy.array_equal(r0, r2))
         self.assertTrue(numpy.allclose(g0, g2))
@@ -94,7 +98,9 @@ class TestRoutines(unittest.TestCase):
         pbc1 = createParallelCalculator(BondCalculator(), 3, map)
         d1 = pbc1(nickel)
         self.assertTrue(numpy.array_equal(d0, d1))
-        pbc2 = createParallelCalculator(BondCalculator(), self.ncpu, self.pool.imap_unordered)
+        pbc2 = createParallelCalculator(
+            BondCalculator(), self.ncpu, self.pool.imap_unordered
+        )
         d2 = pbc2(nickel)
         self.assertTrue(numpy.array_equal(d0, d2))
         bc.rmax = pbc1.rmax = pbc2.rmax = 2.5

--- a/tests/test_pdfbaseline.py
+++ b/tests/test_pdfbaseline.py
@@ -93,8 +93,12 @@ class TestPDFBaseline(unittest.TestCase):
     def test__aliasType(self):
         """Check PDFBaseline._aliasType."""
         self.assertRaises(ValueError, PDFBaseline.createByType, "alias")
-        self.assertRaises(RuntimeError, PDFBaseline._aliasType, "invalid", "alias")
-        self.assertRaises(RuntimeError, PDFBaseline._aliasType, "linear", "zero")
+        self.assertRaises(
+            RuntimeError, PDFBaseline._aliasType, "invalid", "alias"
+        )
+        self.assertRaises(
+            RuntimeError, PDFBaseline._aliasType, "linear", "zero"
+        )
         PDFBaseline._aliasType("linear", "alias")
         bl = PDFBaseline.createByType("alias")
         self.assertEqual("linear", bl.type())
@@ -104,7 +108,9 @@ class TestPDFBaseline(unittest.TestCase):
         bl1 = PDFBaseline.createByType("alias")
         self.assertTrue(isinstance(bl1, LinearBaseline))
         # no other type can be aliased to the existing name.
-        self.assertRaises(RuntimeError, PDFBaseline._aliasType, "zero", "alias")
+        self.assertRaises(
+            RuntimeError, PDFBaseline._aliasType, "zero", "alias"
+        )
         return
 
     def test__deregisterType(self):
@@ -118,7 +124,9 @@ class TestPDFBaseline(unittest.TestCase):
 
     def test_createByType(self):
         """Check PDFBaseline.createByType()"""
-        self.assertRaises(ValueError, PDFBaseline.createByType, "notregistered")
+        self.assertRaises(
+            ValueError, PDFBaseline.createByType, "notregistered"
+        )
         return
 
     def test_isRegisteredType(self):
@@ -136,7 +144,9 @@ class TestPDFBaseline(unittest.TestCase):
         PDFBaseline._aliasType("linear", "bar")
         PDFBaseline._aliasType("linear", "linear")
         PDFBaseline._aliasType("bar", "foo")
-        self.assertEqual({"bar": "linear", "foo": "linear"}, PDFBaseline.getAliasedTypes())
+        self.assertEqual(
+            {"bar": "linear", "foo": "linear"}, PDFBaseline.getAliasedTypes()
+        )
         return
 
     def test_getRegisteredTypes(self):
@@ -161,7 +171,9 @@ class TestPDFBaseline(unittest.TestCase):
 
     def test_makePDFBaseline(self):
         """Check the makePDFBaseline wrapper."""
-        pbl = makePDFBaseline("parabolabaseline", parabola_baseline, a=1, b=2, c=3)
+        pbl = makePDFBaseline(
+            "parabolabaseline", parabola_baseline, a=1, b=2, c=3
+        )
         self.assertEqual(3, pbl(0))
         self.assertEqual(6, pbl(1))
         self.assertEqual(11, pbl(2))
@@ -181,10 +193,28 @@ class TestPDFBaseline(unittest.TestCase):
         self.assertEqual([7, 3, 28], [pbl4(x) for x in [-2, 0, 5]])
         self.assertEqual("bar", pbl4.foo)
         # fail if this baseline type already exists.
-        self.assertRaises(RuntimeError, makePDFBaseline, "linear", parabola_baseline, a=1, b=2, c=3)
-        self.assertRaises(RuntimeError, makePDFBaseline, "parabolabaseline", parabola_baseline, a=1, b=2, c=3)
+        self.assertRaises(
+            RuntimeError,
+            makePDFBaseline,
+            "linear",
+            parabola_baseline,
+            a=1,
+            b=2,
+            c=3,
+        )
+        self.assertRaises(
+            RuntimeError,
+            makePDFBaseline,
+            "parabolabaseline",
+            parabola_baseline,
+            a=1,
+            b=2,
+            c=3,
+        )
         # check replacement of an existing type.
-        makePDFBaseline("linear", parabola_baseline, replace=True, a=1, b=2, c=4)
+        makePDFBaseline(
+            "linear", parabola_baseline, replace=True, a=1, b=2, c=4
+        )
         pbl4 = PDFBaseline.createByType("linear")
         self.assertEqual(set(("a", "b", "c")), pbl4._namesOfDoubleAttributes())
         self.assertEqual(4, pbl4.c)
@@ -196,7 +226,9 @@ class TestPDFBaseline(unittest.TestCase):
 
     def test_picking_owned(self):
         """Verify pickling of PDFBaseline owned by PDF calculators."""
-        pbl = makePDFBaseline("parabolabaseline", parabola_baseline, a=1, b=2, c=3)
+        pbl = makePDFBaseline(
+            "parabolabaseline", parabola_baseline, a=1, b=2, c=3
+        )
         pbl.a = 7
         pbl.foobar = "asdf"
         pc = PDFCalculator()

--- a/tests/test_pdfbaseline.py
+++ b/tests/test_pdfbaseline.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 
-"""Unit tests for the PDFBaseline class from diffpy.srreal.pdfcalculator."""
+"""Unit tests for the PDFBaseline class from
+diffpy.srreal.pdfcalculator."""
 
 
 import pickle

--- a/tests/test_pdfcalcobjcryst.py
+++ b/tests/test_pdfcalcobjcryst.py
@@ -84,19 +84,25 @@ class TestPDFCalcObjcryst(unittest.TestCase):
 
     def test_CdSeN(self):
         """Check PDFCalculator on ObjCryst loaded CIF, neutrons."""
-        self._comparePDFs("cdsen", "CdSe_cadmoselite_N.fgr", "CdSe_cadmoselite.cif")
+        self._comparePDFs(
+            "cdsen", "CdSe_cadmoselite_N.fgr", "CdSe_cadmoselite.cif"
+        )
         self.assertTrue(self.cdsen_mxnd < 0.01)
         return
 
     def test_CdSeX(self):
         """Check PDFCalculator on ObjCryst loaded CIF, xrays."""
-        self._comparePDFs("cdsex", "CdSe_cadmoselite_X.fgr", "CdSe_cadmoselite.cif")
+        self._comparePDFs(
+            "cdsex", "CdSe_cadmoselite_X.fgr", "CdSe_cadmoselite.cif"
+        )
         self.assertTrue(self.cdsex_mxnd < 0.01)
         return
 
     def test_rutileaniso(self):
         """Check PDFCalculator on ObjCryst loaded anisotropic rutile."""
-        self._comparePDFs("rutileaniso", "TiO2_rutile-fit.fgr", "TiO2_rutile-fit.cif")
+        self._comparePDFs(
+            "rutileaniso", "TiO2_rutile-fit.fgr", "TiO2_rutile-fit.cif"
+        )
         self.assertTrue(self.rutileaniso_mxnd < 0.057)
         return
 

--- a/tests/test_pdfcalculator.py
+++ b/tests/test_pdfcalculator.py
@@ -271,7 +271,8 @@ class TestPDFCalculator(unittest.TestCase):
         return
 
     def test_pickling_derived_structure(self):
-        """Check pickling of PDFCalculator with DerivedStructureAdapter."""
+        """Check pickling of PDFCalculator with
+        DerivedStructureAdapter."""
         from testutils import DerivedStructureAdapter
 
         pdfc = self.pdfcalc
@@ -353,7 +354,8 @@ class TestFFTRoutines(unittest.TestCase):
         return
 
     def test_fft_roundtrip(self):
-        """Check if forward and inverse transformation recover the input."""
+        """Check if forward and inverse transformation recover the
+        input."""
         fnipf2 = datafile("Ni-fit.fgr")
         g0 = numpy.loadtxt(fnipf2, usecols=(1,))
         dr0 = 0.01

--- a/tests/test_pdfcalculator.py
+++ b/tests/test_pdfcalculator.py
@@ -252,7 +252,9 @@ class TestPDFCalculator(unittest.TestCase):
         for a in pdfc._namesOfDoubleAttributes():
             self.assertEqual(getattr(pdfc, a), getattr(pdfc1, a))
         self.assertEqual(13.3, pdfc1.getEnvelope("sphericalshape").spdiameter)
-        self.assertEqual(pdfc._namesOfDoubleAttributes(), pdfc1._namesOfDoubleAttributes())
+        self.assertEqual(
+            pdfc._namesOfDoubleAttributes(), pdfc1._namesOfDoubleAttributes()
+        )
         self.assertEqual(pdfc.usedenvelopetypes, pdfc1.usedenvelopetypes)
         self.assertRaises(RuntimeError, pickle_with_attr, pdfc, foo="bar")
         return
@@ -298,7 +300,9 @@ class TestPDFCalculator(unittest.TestCase):
         self.assertEqual("scale", pc.envelopes[0].type())
         pc.envelopes += ("qresolution",)
         self.assertEqual(("qresolution", "scale"), pc.usedenvelopetypes)
-        self.assertTrue(all([isinstance(e, PDFEnvelope) for e in pc.envelopes]))
+        self.assertTrue(
+            all([isinstance(e, PDFEnvelope) for e in pc.envelopes])
+        )
         return
 
 

--- a/tests/test_pdfenvelope.py
+++ b/tests/test_pdfenvelope.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 
-"""Unit tests for the PDFEnvelope class from diffpy.srreal.pdfcalculator."""
+"""Unit tests for the PDFEnvelope class from
+diffpy.srreal.pdfcalculator."""
 
 
 import pickle

--- a/tests/test_pdfenvelope.py
+++ b/tests/test_pdfenvelope.py
@@ -91,7 +91,9 @@ class TestPDFEnvelope(unittest.TestCase):
 
     def test_createByType(self):
         """Check PDFEnvelope.createByType()"""
-        self.assertRaises(ValueError, PDFEnvelope.createByType, "notregistered")
+        self.assertRaises(
+            ValueError, PDFEnvelope.createByType, "notregistered"
+        )
         return
 
     def test_getRegisteredTypes(self):
@@ -114,7 +116,9 @@ class TestPDFEnvelope(unittest.TestCase):
 
     def test_makePDFEnvelope(self):
         """Check the makePDFEnvelope wrapper."""
-        pbl = makePDFEnvelope("parabolaenvelope", parabola_envelope, a=1, b=2, c=3)
+        pbl = makePDFEnvelope(
+            "parabolaenvelope", parabola_envelope, a=1, b=2, c=3
+        )
         self.assertEqual(3, pbl(0))
         self.assertEqual(6, pbl(1))
         self.assertEqual(11, pbl(2))
@@ -138,7 +142,9 @@ class TestPDFEnvelope(unittest.TestCase):
 
     def test_picking_owned(self):
         """Verify pickling of envelopes owned by PDF calculators."""
-        pbl = makePDFEnvelope("parabolaenvelope", parabola_envelope, a=1, b=2, c=3)
+        pbl = makePDFEnvelope(
+            "parabolaenvelope", parabola_envelope, a=1, b=2, c=3
+        )
         pbl.a = 7
         pbl.foobar = "asdf"
         pc = PDFCalculator()
@@ -156,7 +162,10 @@ class TestPDFEnvelope(unittest.TestCase):
         dbpc2 = pickle.loads(pickle.dumps(dbpc))
         self.assertEqual(3.5, pc2.scale)
         self.assertEqual(3.5, dbpc2.scale)
-        pblcopies = [pc2.getEnvelope("parabolaenvelope"), dbpc2.getEnvelope("parabolaenvelope")]
+        pblcopies = [
+            pc2.getEnvelope("parabolaenvelope"),
+            dbpc2.getEnvelope("parabolaenvelope"),
+        ]
         for pbl2 in pblcopies:
             self.assertEqual(7, pbl2.a)
             self.assertEqual("asdf", pbl2.foobar)

--- a/tests/test_peakprofile.py
+++ b/tests/test_peakprofile.py
@@ -28,7 +28,9 @@ class TestPeakProfile(unittest.TestCase):
     def test___init__(self):
         """Check PeakProfile.__init__()"""
         self.assertNotEqual(0.0, self.pkgauss.peakprecision)
-        self.assertEqual(self.pkgauss.peakprecision, self.pkcropped.peakprecision)
+        self.assertEqual(
+            self.pkgauss.peakprecision, self.pkcropped.peakprecision
+        )
         self.pkgauss._setDoubleAttr("peakprecision", 0.01)
         self.assertEqual(0.01, self.pkgauss.peakprecision)
         return

--- a/tests/test_peakprofile.py
+++ b/tests/test_peakprofile.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 
-"""Unit tests for the PeakProfile classes from diffpy.srreal.peakprofile."""
+"""Unit tests for the PeakProfile classes from
+diffpy.srreal.peakprofile."""
 
 
 import pickle
@@ -85,7 +86,8 @@ class TestPeakProfile(unittest.TestCase):
         return
 
     def test_ticker_override(self):
-        """Check method override for PeakProfile.ticker in a derived class."""
+        """Check method override for PeakProfile.ticker in a derived
+        class."""
         pkf = MySawTooth()
         self.assertEqual(0, pkf.tcnt)
         et0 = pkf.ticker()

--- a/tests/test_peakwidthmodel.py
+++ b/tests/test_peakwidthmodel.py
@@ -120,7 +120,8 @@ class TestPeakWidthModel(unittest.TestCase):
         return
 
     def test_ticker_override(self):
-        """Check PeakWidthModel.ticker override in a Python-derived class."""
+        """Check PeakWidthModel.ticker override in a Python-derived
+        class."""
         pwm = MyPWM()
         self.assertEqual(0, pwm.tcnt)
         et0 = pwm.ticker()

--- a/tests/test_peakwidthmodel.py
+++ b/tests/test_peakwidthmodel.py
@@ -101,7 +101,9 @@ class TestPeakWidthModel(unittest.TestCase):
 
     def test_maxWidth(self):
         """Check PeakWidthModel.maxWidth()"""
-        self.assertRaises(RuntimeError, PeakWidthModel().maxWidth, self.tio2adpt, 0, 10)
+        self.assertRaises(
+            RuntimeError, PeakWidthModel().maxWidth, self.tio2adpt, 0, 10
+        )
         self.assertEqual(2.0, self.pwconst.maxWidth(self.tio2adpt, 0, 10))
         self.assertEqual(2.0, self.pwconst.maxWidth(self.tio2stru, 0, 10))
         return
@@ -140,7 +142,9 @@ class TestPeakWidthModel(unittest.TestCase):
         """Check PeakWidthModel.getRegisteredTypes."""
         regtypes = PeakWidthModel.getRegisteredTypes()
         self.assertTrue(3 <= len(regtypes))
-        self.assertTrue(regtypes.issuperset(["constant", "debye-waller", "jeong"]))
+        self.assertTrue(
+            regtypes.issuperset(["constant", "debye-waller", "jeong"])
+        )
         return
 
     def test_pickling(self):

--- a/tests/test_scatteringfactortable.py
+++ b/tests/test_scatteringfactortable.py
@@ -158,7 +158,8 @@ class TestScatteringFactorTable(unittest.TestCase):
         return
 
     def test_derived_create(self):
-        """Check override of ScatteringFactorTable.create in Python class."""
+        """Check override of ScatteringFactorTable.create in Python
+        class."""
         lsft = LocalTable()
         lsft.setCustomAs("Xy", "Na")
         lsft2 = lsft.create()
@@ -167,7 +168,8 @@ class TestScatteringFactorTable(unittest.TestCase):
         return
 
     def test_derived_clone(self):
-        """Check override of ScatteringFactorTable.clone in Python class."""
+        """Check override of ScatteringFactorTable.clone in Python
+        class."""
         lsft = LocalTable()
         lsft.setCustomAs("Xy", "Na")
         lsft2 = lsft.clone()
@@ -176,7 +178,8 @@ class TestScatteringFactorTable(unittest.TestCase):
         return
 
     def test_lookup(self):
-        """Check ScatteringFactorTable.lookup handling of array arguments."""
+        """Check ScatteringFactorTable.lookup handling of array
+        arguments."""
         qa = numpy.linspace(0, 50)
         qb = numpy.array([(x, 0.0) for x in qa])[:, 0]
         self.assertTrue(qb.strides > qa.strides)

--- a/tests/test_scatteringfactortable.py
+++ b/tests/test_scatteringfactortable.py
@@ -184,8 +184,16 @@ class TestScatteringFactorTable(unittest.TestCase):
         fmn0 = numpy.array([sftx.lookup("Mn", x) for x in qa])
         self.assertTrue(numpy.array_equal(fmn0, sftx.lookup("Mn", qa)))
         self.assertTrue(numpy.array_equal(fmn0, sftx.lookup("Mn", qb)))
-        self.assertTrue(numpy.array_equal(fmn0.reshape(5, 10), sftx.lookup("Mn", qa.reshape(5, 10))))
-        self.assertTrue(numpy.array_equal(fmn0.reshape(5, 2, 5), sftx.lookup("Mn", qa.reshape(5, 2, 5))))
+        self.assertTrue(
+            numpy.array_equal(
+                fmn0.reshape(5, 10), sftx.lookup("Mn", qa.reshape(5, 10))
+            )
+        )
+        self.assertTrue(
+            numpy.array_equal(
+                fmn0.reshape(5, 2, 5), sftx.lookup("Mn", qa.reshape(5, 2, 5))
+            )
+        )
         self.assertTrue(numpy.array_equal(fmn0, sftx.lookup("Mn", list(qa))))
         self.assertRaises(TypeError, sftx.lookup, "Na", "asdf")
         self.assertRaises(TypeError, sftx.lookup, "Na", {})

--- a/tests/test_sfaverage.py
+++ b/tests/test_sfaverage.py
@@ -91,7 +91,8 @@ class TestSFAverageObjCryst(unittest.TestCase):
         return
 
     def test_from_rutile(self):
-        """Check SFAverage.fromStructure for pyobjcryst Crystal of rutile."""
+        """Check SFAverage.fromStructure for pyobjcryst Crystal of
+        rutile."""
         rutile = loadObjCrystCrystal("rutile.cif")
         qa = numpy.arange(0, 25, 0.1)
         sfavg = SFAverage.fromStructure(rutile, self.sftx, qa)

--- a/tests/test_sfaverage.py
+++ b/tests/test_sfaverage.py
@@ -49,7 +49,9 @@ class TestSFAverage(unittest.TestCase):
         self.assertTrue(numpy.array_equal(sfavg3.f2sum, sfavg4.f2sum))
         sfavg5 = SFAverage.fromStructure(cdse, "EN", qa)
         self.assertFalse(numpy.array_equal(sfavg3.f1sum, sfavg5.f1sum))
-        self.assertRaises(TypeError, SFAverage.fromStructure, "notastructure", self.sftx)
+        self.assertRaises(
+            TypeError, SFAverage.fromStructure, "notastructure", self.sftx
+        )
         self.assertRaises(ValueError, SFAverage.fromStructure, cdse, "invalid")
         return
 

--- a/tests/test_structureadapter.py
+++ b/tests/test_structureadapter.py
@@ -90,11 +90,19 @@ class TestRoutines(unittest.TestCase):
         self.assertEqual(adpt.countSites(), adpt1.countSites())
         self.assertEqual(adpt.totalOccupancy(), adpt1.totalOccupancy())
         self.assertEqual(adpt.siteAtomType(1), adpt1.siteAtomType(1))
-        self.assertTrue(numpy.array_equal(adpt.siteCartesianPosition(1), adpt1.siteCartesianPosition(1)))
+        self.assertTrue(
+            numpy.array_equal(
+                adpt.siteCartesianPosition(1), adpt1.siteCartesianPosition(1)
+            )
+        )
         self.assertEqual(adpt.siteMultiplicity(1), adpt1.siteMultiplicity(1))
         self.assertEqual(adpt.siteOccupancy(1), adpt1.siteOccupancy(1))
         self.assertTrue(adpt.siteAnisotropy(1) is adpt1.siteAnisotropy(1))
-        self.assertTrue(numpy.array_equal(adpt.siteCartesianUij(1), adpt1.siteCartesianUij(1)))
+        self.assertTrue(
+            numpy.array_equal(
+                adpt.siteCartesianUij(1), adpt1.siteCartesianUij(1)
+            )
+        )
         return
 
     def test_pickle_nonwrapped(self):
@@ -294,10 +302,16 @@ class TestPyObjCrystAdapter(unittest.TestCase):
         self.assertTrue(True is self.rutile.siteAnisotropy(0))
         self.assertTrue(True is self.rutile.siteAnisotropy(1))
         self.assertTrue(
-            numpy.allclose(numpy.diag([0.008698, 0.008698, 0.005492]), self.rutile.siteCartesianUij(0))
+            numpy.allclose(
+                numpy.diag([0.008698, 0.008698, 0.005492]),
+                self.rutile.siteCartesianUij(0),
+            )
         )
         self.assertTrue(
-            numpy.allclose(numpy.diag([0.021733, 0.021733, 0.007707]), self.rutile.siteCartesianUij(1))
+            numpy.allclose(
+                numpy.diag([0.021733, 0.021733, 0.007707]),
+                self.rutile.siteCartesianUij(1),
+            )
         )
         return
 
@@ -592,7 +606,14 @@ class TestAtom(unittest.TestCase):
         a.uc13 = 0.013
         a.uc23 = 0.023
         self.assertTrue(
-            numpy.array_equal(a.uij_cartn, [[0.01, 0.012, 0.013], [0.012, 0.01, 0.023], [0.013, 0.023, 0.01]])
+            numpy.array_equal(
+                a.uij_cartn,
+                [
+                    [0.01, 0.012, 0.013],
+                    [0.012, 0.01, 0.023],
+                    [0.013, 0.023, 0.01],
+                ],
+            )
         )
         self.assertEqual(0.01, a.uc11)
         self.assertEqual(0.01, a.uc22)

--- a/tests/test_structureadapter.py
+++ b/tests/test_structureadapter.py
@@ -74,7 +74,8 @@ class TestRoutines(unittest.TestCase):
         return
 
     def test_createStructureAdapter_int64_occupancy(self):
-        """Check Structure conversion when occupany is of numpy.int64 type."""
+        """Check Structure conversion when occupany is of numpy.int64
+        type."""
         self.nickel[0].occupancy = numpy.int64(0)
         self.nickel[1].occupancy = numpy.int64(1)
         adpt = createStructureAdapter(self.nickel)
@@ -259,7 +260,8 @@ class TestNoSymmetry(unittest.TestCase):
         return
 
     def test_nosymmetry_twice(self):
-        """Check that second call of nosymmetry returns the same object."""
+        """Check that second call of nosymmetry returns the same
+        object."""
         adpt1 = nosymmetry(self.nickel)
         adpt2 = nosymmetry(adpt1)
         self.assertTrue(adpt1 is adpt2)
@@ -348,14 +350,16 @@ class IndexRangeTests(object):
         return
 
     def test_siteCartesianPositionIndex(self):
-        """Check out-of-range arguments in AdptClass.siteCartesianPosition."""
+        """Check out-of-range arguments in
+        AdptClass.siteCartesianPosition."""
         cnt = self.adpt.countSites()
         self.assertRaises(IndexError, self.adpt.siteCartesianPosition, cnt)
         self.assertRaises(IndexError, self.adpt.siteCartesianPosition, -1)
         return
 
     def test_siteMultiplicityIndex(self):
-        """Check out-of-range arguments in AdptClass.siteMultiplicity."""
+        """Check out-of-range arguments in
+        AdptClass.siteMultiplicity."""
         cnt = self.adpt.countSites()
         self.assertRaises(IndexError, self.adpt.siteMultiplicity, cnt)
         self.assertRaises(IndexError, self.adpt.siteMultiplicity, -1)
@@ -376,7 +380,8 @@ class IndexRangeTests(object):
         return
 
     def test_siteCartesianUijIndex(self):
-        """Check out-of-range arguments in AdptClass.siteCartesianUij."""
+        """Check out-of-range arguments in
+        AdptClass.siteCartesianUij."""
         cnt = self.adpt.countSites()
         self.assertRaises(IndexError, self.adpt.siteCartesianUij, cnt)
         self.assertRaises(IndexError, self.adpt.siteCartesianUij, -1)

--- a/tests/testutils.py
+++ b/tests/testutils.py
@@ -142,11 +142,15 @@ class DerivedAtomicStructureAdapter(HasCustomPQConfig, AtomicStructureAdapter):
     pass
 
 
-class DerivedPeriodicStructureAdapter(HasCustomPQConfig, PeriodicStructureAdapter):
+class DerivedPeriodicStructureAdapter(
+    HasCustomPQConfig, PeriodicStructureAdapter
+):
     pass
 
 
-class DerivedCrystalStructureAdapter(HasCustomPQConfig, CrystalStructureAdapter):
+class DerivedCrystalStructureAdapter(
+    HasCustomPQConfig, CrystalStructureAdapter
+):
     pass
 
 


### PR DESCRIPTION
The last autofix PR had a black linelength requirement of 115. This PR changes this to 79 (skpkg standard) and makes those auto fixes. 

There are only two flake8 errors that need to be addressed regarding line length. Because these are simple and quick, I will also put them on this PR and make note inline of where exactly I made these manual fixes.