### PR TITLE
refactor: migrate Boost.Python syntax to nanobind

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,7 @@ ci:
   submodules: false
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.6.0
+    rev: v6.0.0
     hooks:
       - id: check-yaml
       - id: end-of-file-fixer
@@ -21,31 +21,31 @@ repos:
       - id: check-toml
       - id: check-added-large-files
   - repo: https://github.com/psf/black
-    rev: 24.4.2
+    rev: 26.3.1
     hooks:
       - id: black
   - repo: https://github.com/pycqa/flake8
-    rev: 7.0.0
+    rev: 7.3.0
     hooks:
       - id: flake8
   - repo: https://github.com/pycqa/isort
-    rev: 5.13.2
+    rev: 9.0.0a3
     hooks:
       - id: isort
         args: ["--profile", "black"]
   - repo: https://github.com/kynan/nbstripout
-    rev: 0.7.1
+    rev: 0.9.1
     hooks:
       - id: nbstripout
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.4.0
+    rev: v6.0.0
     hooks:
       - id: no-commit-to-branch
         name: Prevent Commit to Main Branch
         args: ["--branch", "main"]
         stages: [pre-commit]
   - repo: https://github.com/codespell-project/codespell
-    rev: v2.3.0
+    rev: v2.4.2
     hooks:
       - id: codespell
         additional_dependencies:
@@ -58,8 +58,8 @@ repos:
         additional_dependencies:
           - "prettier@^3.2.4"
   # docformatter - PEP 257 compliant docstring formatter
-  - repo: https://github.com/s-weigand/docformatter
-    rev: 5757c5190d95e5449f102ace83df92e7d3b06c6c
+  - repo: https://github.com/PyCQA/docformatter
+    rev: v1.7.8
     hooks:
       - id: docformatter
         additional_dependencies: [tomli]

--- a/news/cpp-version-update.rst
+++ b/news/cpp-version-update.rst
@@ -1,0 +1,24 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* updated cpp minimum version to c++23.
+* replaced boost smart pointer usages with stl implementations.
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/news/precommit-deps-update.rst
+++ b/news/precommit-deps-update.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* No news needed: updating pre-commit hooks, black, flake8, isort, nbstripout, codespell and docformatter. Not user facing.
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,10 @@
 [build-system]
-requires = ["setuptools>=62.0", "setuptools-git-versioning>=2.0", "numpy"]
+requires = [
+    "setuptools>=62.0",
+    "setuptools-git-versioning>=2.0",
+    "numpy",
+    "nanobind",
+]
 build-backend = "setuptools.build_meta"
 
 [project]

--- a/requirements/conda.txt
+++ b/requirements/conda.txt
@@ -4,3 +4,4 @@ libobjcryst
 pyobjcryst
 diffpy.structure
 periodictable
+nanobind

--- a/setup.py
+++ b/setup.py
@@ -90,11 +90,11 @@ def get_objcryst_libraries():
 
 
 if os.name == "nt":
-    compile_args = ["/std:c++14"]
+    compile_args = ["/std:c++23"]
     macros = [("_USE_MATH_DEFINES", None)]
     extra_link_args = ["/FORCE:MULTIPLE"]
 else:
-    compile_args = ["-std=c++11"]
+    compile_args = ["-std=c++23"]
     macros = []
     extra_link_args = []
 

--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,7 @@ def get_nanobind_config():
         "source": str(Path(nanobind.source_dir()) / "nb_combined.cpp"),
     }
 
+
 nanobind_macros = [("NB_COMPACT_ASSERTIONS", None)]
 
 
@@ -179,4 +180,7 @@ def ext_modules():
 
 
 if __name__ == "__main__":
-    setup(cmdclass={"build_ext": build_ext_with_nanobind}, ext_modules=ext_modules())
+    setup(
+        cmdclass={"build_ext": build_ext_with_nanobind},
+        ext_modules=ext_modules(),
+    )

--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,22 @@ from pathlib import Path
 
 import numpy
 from setuptools import Extension, setup
+from setuptools.command.build_ext import build_ext
+
+
+def get_nanobind_config():
+    import nanobind
+
+    package_dir = Path(nanobind.__file__).parent
+    return {
+        "include_dirs": [
+            nanobind.include_dir(),
+            str(package_dir / "ext" / "robin_map" / "include"),
+        ],
+        "source": str(Path(nanobind.source_dir()) / "nb_combined.cpp"),
+    }
+
+nanobind_macros = [("NB_COMPACT_ASSERTIONS", None)]
 
 
 def get_boost_libraries():
@@ -91,10 +107,12 @@ def get_objcryst_libraries():
 
 if os.name == "nt":
     compile_args = ["/std:c++23"]
+    nanobind_compile_args = ["/std:c++23"]
     macros = [("_USE_MATH_DEFINES", None)]
     extra_link_args = ["/FORCE:MULTIPLE"]
 else:
     compile_args = ["-std=c++23"]
+    nanobind_compile_args = ["-std=c++23", "-fno-strict-aliasing"]
     macros = []
     extra_link_args = []
 
@@ -112,13 +130,44 @@ ext_kws = {
 }
 
 
+class build_ext_with_nanobind(build_ext):
+    def build_extension(self, ext):
+        nanobind_source = getattr(ext, "nanobind_source", None)
+        if not nanobind_source:
+            super().build_extension(ext)
+            return
+
+        original_extra_objects = list(ext.extra_objects or [])
+        try:
+            nanobind_objects = self.compiler.compile(
+                [nanobind_source],
+                output_dir=self.build_temp,
+                macros=(ext.define_macros or []) + nanobind_macros,
+                include_dirs=ext.include_dirs,
+                debug=self.debug,
+                extra_postargs=nanobind_compile_args,
+                depends=ext.depends,
+            )
+            ext.extra_objects = original_extra_objects + nanobind_objects
+            super().build_extension(ext)
+        finally:
+            ext.extra_objects = original_extra_objects
+
+
 def create_extensions():
     "Initialize Extension objects for the setup function."
+    nanobind_cfg = get_nanobind_config()
     ext = Extension(
         "diffpy.srreal.srreal_ext",
         glob.glob("src/extensions/*.cpp"),
-        **ext_kws,
+        **{
+            **ext_kws,
+            "include_dirs": (
+                ext_kws["include_dirs"] + nanobind_cfg["include_dirs"]
+            ),
+        },
     )
+    ext.nanobind_source = nanobind_cfg["source"]
     return [ext]
 
 
@@ -130,4 +179,4 @@ def ext_modules():
 
 
 if __name__ == "__main__":
-    setup(ext_modules=ext_modules())
+    setup(cmdclass={"build_ext": build_ext_with_nanobind}, ext_modules=ext_modules())

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,6 @@ Packages:   diffpy.srreal
 import glob
 import os
 import sys
-from ctypes.util import find_library
 from pathlib import Path
 
 import numpy
@@ -31,30 +30,6 @@ def get_nanobind_config():
 
 
 nanobind_macros = [("NB_COMPACT_ASSERTIONS", None)]
-
-
-def get_boost_libraries():
-    major, minor = sys.version_info[:2]
-    candidates = [
-        f"boost_python{major}{minor}",
-        f"boost_python{major}",
-        "boost_python",
-    ]
-
-    conda_prefix = os.environ.get("CONDA_PREFIX")
-    if conda_prefix:
-        libdir = os.path.join(conda_prefix, "lib")
-        for name in candidates:
-            so = f"lib{name}.so"
-            if os.path.isfile(os.path.join(libdir, so)):
-                return [name]
-
-    # fallback to ldconfig
-    for name in candidates:
-        found = find_library(name)
-        if found:
-            return [name]
-    raise RuntimeError("Cannot find a suitable Boost.Python library.")
 
 
 def get_boost_config():
@@ -121,7 +96,7 @@ boost_cfg = get_boost_config()
 objcryst_libs = get_objcryst_libraries()
 
 ext_kws = {
-    "libraries": ["diffpy"] + get_boost_libraries() + objcryst_libs,
+    "libraries": ["diffpy"] + objcryst_libs,
     "extra_compile_args": compile_args,
     "extra_link_args": extra_link_args,
     "include_dirs": [numpy.get_include()] + boost_cfg["include_dirs"],

--- a/src/diffpy/__init__.py
+++ b/src/diffpy/__init__.py
@@ -14,7 +14,6 @@
 ##############################################################################
 """Blank namespace package for module diffpy."""
 
-
 from pkgutil import extend_path
 
 __path__ = extend_path(__path__, __name__)

--- a/src/diffpy/srreal/_cleanup.py
+++ b/src/diffpy/srreal/_cleanup.py
@@ -24,7 +24,6 @@ This module is not intended for direct use.  It is used implicitly within
 a call of _registerThisType.
 """
 
-
 import atexit
 import weakref
 

--- a/src/diffpy/srreal/_final_imports.py
+++ b/src/diffpy/srreal/_final_imports.py
@@ -15,13 +15,15 @@
 """Finalize tweak of classes from the extension module srreal_ext.
 
 This private module handles loading of Python-level tweaks of the
-extension-defined classes.  Any client that imports this module
-must call the `import_now` function.  If this module is not loaded
-by the time of srreal_ext initialization, `import_now` is executed
-from srreal_ext.
+extension-defined classes.  Any client that imports this module must
+call the `import_now` function.  If this module is not loaded by the
+time of srreal_ext initialization, `import_now` is executed from
+srreal_ext.
 
 This avoids unresolvable import dependencies for any order of imports.
 """
+
+_import_now_called = False
 
 
 def import_now():
@@ -46,6 +48,3 @@ def import_now():
     import_module("diffpy.srreal.pdfcalculator")
     import_module("diffpy.srreal.structureconverters")
     return
-
-
-_import_now_called = False

--- a/src/diffpy/srreal/atomradiitable.py
+++ b/src/diffpy/srreal/atomradiitable.py
@@ -14,7 +14,6 @@
 ##############################################################################
 """Class AtomRadiiTable -- storage of empirical atom radii."""
 
-
 # exported items, these also makes them show in pydoc.
 __all__ = ["AtomRadiiTable", "ConstantRadiiTable", "CovalentRadiiTable"]
 
@@ -66,8 +65,9 @@ class CovalentRadiiTable(AtomRadiiTable):
         return copy.copy(self)
 
     def type(self):
-        """Unique string identifier of the CovalentRadiiTable type. This
-        is used for class registration and as an argument for the
+        """Unique string identifier of the CovalentRadiiTable type.
+
+        This is used for class registration and as an argument for the
         createByType function.
 
         Return string.

--- a/src/diffpy/srreal/attributes.py
+++ b/src/diffpy/srreal/attributes.py
@@ -13,7 +13,7 @@
 #
 ##############################################################################
 """class Attributes  -- wrapper to C++ class diffpy::Attributes
-    A base to PairQuantity and quite a few other classes.
+A base to PairQuantity and quite a few other classes.
 """
 
 __all__ = ["Attributes"]

--- a/src/diffpy/srreal/bondcalculator.py
+++ b/src/diffpy/srreal/bondcalculator.py
@@ -14,7 +14,6 @@
 ##############################################################################
 """Class BondCalculator -- distances between atoms in the structure."""
 
-
 # exported items, these also makes them show in pydoc.
 __all__ = ["BondCalculator"]
 
@@ -28,14 +27,12 @@ from diffpy.srreal.wraputils import (
 
 BondCalculator.rmin = propertyFromExtDoubleAttr(
     "rmin",
-    """Lower bound for the bond distances.
-        [0 A]""",
+    "Lower bound for the bond distances. [0 A]",
 )
 
 BondCalculator.rmax = propertyFromExtDoubleAttr(
     "rmax",
-    """Upper bound for the bond distances.
-        [5 A]""",
+    "Upper bound for the bond distances. [5 A]",
 )
 
 

--- a/src/diffpy/srreal/bondcalculator.py
+++ b/src/diffpy/srreal/bondcalculator.py
@@ -17,11 +17,45 @@
 # exported items, these also makes them show in pydoc.
 __all__ = ["BondCalculator"]
 
-from diffpy.srreal.srreal_ext import BondCalculator
+from diffpy.srreal.srreal_ext import BondCalculator as _BondCalculator
 from diffpy.srreal.wraputils import (
     propertyFromExtDoubleAttr,
     setattrFromKeywordArguments,
 )
+
+
+class BondCalculator(_BondCalculator):
+    __doc__ = _BondCalculator.__doc__
+
+    def __init__(self, **kwargs):
+        """Create a new instance of BondCalculator. Keyword arguments can be
+        used to configure calculator properties, for example:
+
+        bdc = BondCalculator(rmin=1.5, rmax=2.5)
+
+        Raise ValueError for invalid keyword argument.
+        """
+        super().__init__()
+        setattrFromKeywordArguments(self, **kwargs)
+        return
+
+    def __call__(self, structure=None, **kwargs):
+        """Return sorted bond distances in the specified structure.
+
+        Attributes
+        ----------
+        structure
+            structure to be evaluated, an instance of diffpy Structure
+            or pyobjcryst Crystal.  Reuse the last structure when None.
+        kwargs
+            optional parameter settings for this calculator
+
+        Return a sorted numpy array.
+        """
+        setattrFromKeywordArguments(self, **kwargs)
+        self.eval(structure)
+        return self.distances
+
 
 # property wrappers to C++ double attributes
 
@@ -35,43 +69,5 @@ BondCalculator.rmax = propertyFromExtDoubleAttr(
     "Upper bound for the bond distances. [5 A]",
 )
 
-
-# method overrides that support keyword arguments
-
-
-def _init_kwargs(self, **kwargs):
-    """Create a new instance of BondCalculator. Keyword arguments can be
-    used to configure calculator properties, for example:
-
-    bdc = BondCalculator(rmin=1.5, rmax=2.5)
-
-    Raise ValueError for invalid keyword argument.
-    """
-    BondCalculator.__boostpython__init(self)
-    setattrFromKeywordArguments(self, **kwargs)
-    return
-
-
-def _call_kwargs(self, structure=None, **kwargs):
-    """Return sorted bond distances in the specified structure.
-
-    Attributes
-    ----------
-    structure
-        structure to be evaluated, an instance of diffpy Structure
-        or pyobjcryst Crystal.  Reuse the last structure when None.
-    kwargs
-        optional parameter settings for this calculator
-
-    Return a sorted numpy array.
-    """
-    setattrFromKeywordArguments(self, **kwargs)
-    self.eval(structure)
-    return self.distances
-
-
-BondCalculator.__boostpython__init = BondCalculator.__init__
-BondCalculator.__init__ = _init_kwargs
-BondCalculator.__call__ = _call_kwargs
 
 # End of file

--- a/src/diffpy/srreal/bvparameterstable.py
+++ b/src/diffpy/srreal/bvparameterstable.py
@@ -15,7 +15,6 @@
 """Class BVParametersTable -- storage of bond valence parameters class BVParam
 -- bond valence data associated with specific cation-anion pair."""
 
-
 # exported items, these also makes them show in pydoc.
 __all__ = ["BVParam", "BVParametersTable"]
 

--- a/src/diffpy/srreal/bvscalculator.py
+++ b/src/diffpy/srreal/bvscalculator.py
@@ -14,7 +14,6 @@
 ##############################################################################
 """Class BVSCalculator -- bond valence sums calculator."""
 
-
 # exported items
 __all__ = ["BVSCalculator"]
 
@@ -28,30 +27,32 @@ from diffpy.srreal.wraputils import (
 
 BVSCalculator.valenceprecision = propertyFromExtDoubleAttr(
     "valenceprecision",
-    """Cutoff value for valence contributions at long distances.
-        [1e-5]""",
+    "Cutoff value for valence contributions at long distances. [1e-5]",
 )
 
 BVSCalculator.rmaxused = propertyFromExtDoubleAttr(
     "rmaxused",
-    """Effective bound for bond lengths, where valence contributions
-        become smaller than valenceprecission, read-only.  Always smaller or
-        equal to rmax.  The value depends on ions present in the structure.
-        """,
+    (
+        "Effective bound for bond lengths, where valence contributions"
+        " become smaller than valenceprecission, read-only."
+        "  Always smaller or equal to rmax."
+        "  The value depends on ions present in the structure."
+    ),
 )
 
 BVSCalculator.rmin = propertyFromExtDoubleAttr(
     "rmin",
-    """Lower bound for the summed bond lengths.
-        [0 A]""",
+    "Lower bound for the summed bond lengths. [0 A]",
 )
 
 BVSCalculator.rmax = propertyFromExtDoubleAttr(
     "rmax",
-    """Upper bound for the summed bond lengths.  The calculation is
-        actually cut off much earlier when valence contributions get below
-        valenceprecission.  See also rmaxused and valenceprecission.
-        [1e6 A]""",
+    (
+        "Upper bound for the summed bond lengths."
+        "  The calculation is actually cut off much earlier when"
+        " valence contributions get below valenceprecission."
+        "  See also rmaxused and valenceprecission. [1e6 A]"
+    ),
 )
 
 

--- a/src/diffpy/srreal/bvscalculator.py
+++ b/src/diffpy/srreal/bvscalculator.py
@@ -17,11 +17,47 @@
 # exported items
 __all__ = ["BVSCalculator"]
 
-from diffpy.srreal.srreal_ext import BVSCalculator
+from diffpy.srreal.srreal_ext import BVSCalculator as _BVSCalculator
 from diffpy.srreal.wraputils import (
     propertyFromExtDoubleAttr,
     setattrFromKeywordArguments,
 )
+
+
+class BVSCalculator(_BVSCalculator):
+    __doc__ = _BVSCalculator.__doc__
+
+    def __init__(self, **kwargs):
+        """Create a new instance of BVSCalculator.
+        Keyword arguments can be used to configure the calculator properties,
+        for example:
+
+        bvscalc = BVSCalculator(valenceprecision=0.001)
+
+        Raise ValueError for invalid keyword argument.
+        """
+        super().__init__()
+        setattrFromKeywordArguments(self, **kwargs)
+        return
+
+    def __call__(self, structure=None, **kwargs):
+        """Return bond valence sums at each atom site in the structure.
+
+        Attributes
+        ----------
+        structure
+            structure to be evaluated, an instance of diffpy Structure
+            or pyobjcryst Crystal.  Reuse the last structure when None.
+        kwargs
+            optional parameter settings for this calculator
+
+        Return an array of calculated valence sums.
+        See valences for the expected values.
+        """
+        setattrFromKeywordArguments(self, **kwargs)
+        rv = self.eval(structure)
+        return rv
+
 
 # Property wrappers to C++ double attributes
 
@@ -55,45 +91,5 @@ BVSCalculator.rmax = propertyFromExtDoubleAttr(
     ),
 )
 
-
-# method overrides that support keyword arguments
-
-
-def _init_kwargs(self, **kwargs):
-    """Create a new instance of BVSCalculator.
-    Keyword arguments can be used to configure the calculator properties,
-    for example:
-
-    bvscalc = BVSCalculator(valenceprecision=0.001)
-
-    Raise ValueError for invalid keyword argument.
-    """
-    BVSCalculator.__boostpython__init(self)
-    setattrFromKeywordArguments(self, **kwargs)
-    return
-
-
-def _call_kwargs(self, structure=None, **kwargs):
-    """Return bond valence sums at each atom site in the structure.
-
-    Attributes
-    ----------
-    structure
-        structure to be evaluated, an instance of diffpy Structure
-        or pyobjcryst Crystal.  Reuse the last structure when None.
-    kwargs
-        optional parameter settings for this calculator
-
-    Return an array of calculated valence sums.
-    See valences for the expected values.
-    """
-    setattrFromKeywordArguments(self, **kwargs)
-    rv = self.eval(structure)
-    return rv
-
-
-BVSCalculator.__boostpython__init = BVSCalculator.__init__
-BVSCalculator.__init__ = _init_kwargs
-BVSCalculator.__call__ = _call_kwargs
 
 # End of file

--- a/src/diffpy/srreal/eventticker.py
+++ b/src/diffpy/srreal/eventticker.py
@@ -15,7 +15,6 @@
 """Class EventTicker -- storage of modification times of dependent
 objects."""
 
-
 # exported items
 __all__ = ["EventTicker"]
 

--- a/src/diffpy/srreal/overlapcalculator.py
+++ b/src/diffpy/srreal/overlapcalculator.py
@@ -15,7 +15,6 @@
 """Class OverlapCalculator -- calculator of atom overlaps in a
 structure."""
 
-
 # exported items, these also makes them show in pydoc.
 __all__ = ["OverlapCalculator"]
 
@@ -29,22 +28,21 @@ from diffpy.srreal.wraputils import (
 
 OverlapCalculator.rmin = propertyFromExtDoubleAttr(
     "rmin",
-    """Lower bound for the bond distances.
-        [0 A]""",
+    "Lower bound for the bond distances. [0 A]",
 )
 
 OverlapCalculator.rmax = propertyFromExtDoubleAttr(
     "rmax",
-    """Upper bound for the bond distances.
-        [5 A]""",
+    "Upper bound for the bond distances. [5 A]",
 )
 
 OverlapCalculator.rmaxused = propertyFromExtDoubleAttr(
     "rmaxused",
-    """Effective upper bound for the bond distances.
-        rmaxused equals either a double of the maximum atom radius
-        in the structure or rmax.
-        """,
+    (
+        "Effective upper bound for the bond distances."
+        " rmaxused equals either a double of the maximum"
+        " atom radius in the structure or rmax."
+    ),
 )
 
 # method overrides that support keyword arguments

--- a/src/diffpy/srreal/overlapcalculator.py
+++ b/src/diffpy/srreal/overlapcalculator.py
@@ -18,11 +18,45 @@ structure."""
 # exported items, these also makes them show in pydoc.
 __all__ = ["OverlapCalculator"]
 
-from diffpy.srreal.srreal_ext import OverlapCalculator
+from diffpy.srreal.srreal_ext import OverlapCalculator as _OverlapCalculator
 from diffpy.srreal.wraputils import (
     propertyFromExtDoubleAttr,
     setattrFromKeywordArguments,
 )
+
+
+class OverlapCalculator(_OverlapCalculator):
+    __doc__ = _OverlapCalculator.__doc__
+
+    def __init__(self, **kwargs):
+        """Create a new instance of OverlapCalculator. Keyword arguments can
+        be used to configure calculator properties, for example:
+
+        olc = OverlapCalculator(rmax=2.5)
+
+        Raise ValueError for invalid keyword argument.
+        """
+        super().__init__()
+        setattrFromKeywordArguments(self, **kwargs)
+        return
+
+    def __call__(self, structure=None, **kwargs):
+        """Return siteSquareOverlaps per each site of the structure.
+
+        Attributes
+        ----------
+        structure
+            structure to be evaluated, an instance of diffpy Structure
+            or pyobjcryst Crystal.  Reuse the last structure when None.
+        kwargs
+            optional parameter settings for this calculator
+
+        Return a numpy array.
+        """
+        setattrFromKeywordArguments(self, **kwargs)
+        self.eval(structure)
+        return self.sitesquareoverlaps
+
 
 # property wrappers to C++ double attributes
 
@@ -44,43 +78,5 @@ OverlapCalculator.rmaxused = propertyFromExtDoubleAttr(
         " atom radius in the structure or rmax."
     ),
 )
-
-# method overrides that support keyword arguments
-
-
-def _init_kwargs(self, **kwargs):
-    """Create a new instance of OverlapCalculator. Keyword arguments can
-    be used to configure calculator properties, for example:
-
-    olc = OverlapCalculator(rmax=2.5)
-
-    Raise ValueError for invalid keyword argument.
-    """
-    OverlapCalculator.__boostpython__init(self)
-    setattrFromKeywordArguments(self, **kwargs)
-    return
-
-
-def _call_kwargs(self, structure=None, **kwargs):
-    """Return siteSquareOverlaps per each site of the structure.
-
-    Attributes
-    ----------
-    structure
-        structure to be evaluated, an instance of diffpy Structure
-        or pyobjcryst Crystal.  Reuse the last structure when None.
-    kwargs
-        optional parameter settings for this calculator
-
-    Return a numpy array.
-    """
-    setattrFromKeywordArguments(self, **kwargs)
-    self.eval(structure)
-    return self.sitesquareoverlaps
-
-
-OverlapCalculator.__boostpython__init = OverlapCalculator.__init__
-OverlapCalculator.__init__ = _init_kwargs
-OverlapCalculator.__call__ = _call_kwargs
 
 # End of file

--- a/src/diffpy/srreal/pairquantity.py
+++ b/src/diffpy/srreal/pairquantity.py
@@ -15,7 +15,6 @@
 """Class PairQuantity    -- base class for Python defined
 calculators."""
 
-
 # exported items
 __all__ = ["PairQuantity"]
 

--- a/src/diffpy/srreal/parallel.py
+++ b/src/diffpy/srreal/parallel.py
@@ -16,7 +16,6 @@
 into parallel calculators.
 """
 
-
 # exported items
 __all__ = ["createParallelCalculator"]
 
@@ -48,8 +47,10 @@ def createParallelCalculator(pqobj, ncpu, pmap):
     """
 
     class ParallelPairQuantity(Attributes):
-        """Class for running parallel calculations.  This is a proxy
-        class to the wrapper PairQuantity type with the same interface.
+        """Class for running parallel calculations.
+
+        This is a proxy class to the wrapper PairQuantity type
+        with the same interface.
 
         Instance data:
 
@@ -144,7 +145,7 @@ def createParallelCalculator(pqobj, ncpu, pmap):
 
         @property
         def evaluatortype(self):
-            """str : Type of evaluation procedure.
+            """Str : Type of evaluation procedure.
 
             Parallel calculations allow only the 'BASIC' type.
             """
@@ -166,11 +167,9 @@ def createParallelCalculator(pqobj, ncpu, pmap):
 
     # create proxy methods to all public methods and some protected methods
 
-    proxy_forced = set(
-        """_getDoubleAttr _setDoubleAttr _hasDoubleAttr
+    proxy_forced = set("""_getDoubleAttr _setDoubleAttr _hasDoubleAttr
         _namesOfDoubleAttributes _namesOfWritableDoubleAttributes
-        """.split()
-    )
+        """.split())
 
     def _make_proxymethod(name, f):
         def proxymethod(self, *args, **kwargs):

--- a/src/diffpy/srreal/pdfbaseline.py
+++ b/src/diffpy/srreal/pdfbaseline.py
@@ -17,7 +17,6 @@ Classes for configuring PDF baseline:
     PDFBaseline, ZeroBaseline, LinearBaseline
 """
 
-
 # exported items
 __all__ = """
     PDFBaseline makePDFBaseline
@@ -40,8 +39,10 @@ ZeroBaseline.__getstate_manages_dict__ = None
 
 LinearBaseline.slope = propertyFromExtDoubleAttr(
     "slope",
-    """Slope of an unscaled linear baseline.  For crystal structures it
-    is preset to (-4 * pi * rho0).""",
+    (
+        "Slope of an unscaled linear baseline.  For crystal structures it"
+        " is preset to (-4 * pi * rho0)."
+    ),
 )
 
 # Python functions wrapper

--- a/src/diffpy/srreal/pdfcalculator.py
+++ b/src/diffpy/srreal/pdfcalculator.py
@@ -88,77 +88,78 @@ assert all(
 def _defineCommonInterface(cls):
     """This function defines shared properties of PDF calculator
     classes."""
-
     cls.scale = propertyFromExtDoubleAttr(
         "scale",
-        """Scale factor of the calculated PDF.  Active for ScaleEnvelope.
-        [1.0 unitless]""",
+        (
+            "Scale factor of the calculated PDF."
+            "  Active for ScaleEnvelope. [1.0 unitless]"
+        ),
     )
 
     cls.delta1 = propertyFromExtDoubleAttr(
         "delta1",
-        """Coefficient for (1/r) contribution to the peak sharpening.
-        Active for JeongPeakWidth model.
-        [0 A]""",
+        (
+            "Coefficient for (1/r) contribution to the peak sharpening."
+            "  Active for JeongPeakWidth model. [0 A]"
+        ),
     )
 
     cls.delta2 = propertyFromExtDoubleAttr(
         "delta2",
-        """Coefficient for (1/r**2) contribution to the peak sharpening.
-        Active for JeongPeakWidth model.
-        [0 A**2]""",
+        (
+            "Coefficient for (1/r**2) contribution to the peak sharpening."
+            "  Active for JeongPeakWidth model. [0 A**2]"
+        ),
     )
 
     cls.qdamp = propertyFromExtDoubleAttr(
         "qdamp",
-        """PDF Gaussian dampening factor due to limited Q-resolution.
-        Not applied when equal to zero.  Active for QResolutionEnvelope.
-        [0 1/A]""",
+        (
+            "PDF Gaussian dampening factor due to limited Q-resolution."
+            "  Not applied when equal to zero."
+            "  Active for QResolutionEnvelope. [0 1/A]"
+        ),
     )
 
     cls.qbroad = propertyFromExtDoubleAttr(
         "qbroad",
-        """PDF peak broadening from increased intensity noise at high Q.
-        Not applied when equal zero.  Active for JeongPeakWidth model.
-        [0 1/A]""",
+        (
+            "PDF peak broadening from increased intensity noise at high Q."
+            "  Not applied when equal zero."
+            "  Active for JeongPeakWidth model. [0 1/A]"
+        ),
     )
 
     cls.extendedrmin = propertyFromExtDoubleAttr(
         "extendedrmin",
-        """Low boundary of the extended r-range, read-only.
-        [A]""",
+        "Low boundary of the extended r-range, read-only. [A]",
     )
 
     cls.extendedrmax = propertyFromExtDoubleAttr(
         "extendedrmax",
-        """Upper boundary of the extended r-range, read-only.
-        [A]""",
+        "Upper boundary of the extended r-range, read-only. [A]",
     )
-
     cls.maxextension = propertyFromExtDoubleAttr(
         "maxextension",
-        """Maximum extension of the r-range that accounts for contributions
-        from the out of range peaks.
-        [10 A]""",
+        (
+            "Maximum extension of the r-range that accounts for"
+            " contributions from the out of range peaks. [10 A]"
+        ),
     )
-
     cls.rmin = propertyFromExtDoubleAttr(
         "rmin",
-        """Lower bound of the r-grid for PDF calculation.
-        [0 A]""",
+        "Lower bound of the r-grid for PDF calculation. [0 A]",
     )
-
     cls.rmax = propertyFromExtDoubleAttr(
         "rmax",
-        """Upper bound of the r-grid for PDF calculation.
-        [10 A]""",
+        "Upper bound of the r-grid for PDF calculation. [10 A]",
     )
-
     cls.rstep = propertyFromExtDoubleAttr(
         "rstep",
-        """Spacing in the calculated r-grid.  r-values are at the
-        multiples of rstep.
-        [0.01 A]""",
+        (
+            "Spacing in the calculated r-grid."
+            "  r-values are at the multiples of rstep. [0.01 A]"
+        ),
     )
 
     def _call_kwargs(self, structure=None, **kwargs):
@@ -197,36 +198,36 @@ def _defineCommonInterface(cls):
 # shared interface of the PDF calculator classes
 
 _defineCommonInterface(DebyePDFCalculator)
-
 # Property wrappers to double attributes of the C++ DebyePDFCalculator
 
 DebyePDFCalculator.debyeprecision = propertyFromExtDoubleAttr(
     "debyeprecision",
-    """Cutoff amplitude for the sine contributions to the F(Q).
-        [1e-6 unitless]""",
+    "Cutoff amplitude for the sine contributions to the F(Q). [1e-6 unitless]",
 )
 
 DebyePDFCalculator.qmin = propertyFromExtDoubleAttr(
     "qmin",
-    """Lower bound of the Q-grid for the calculated F(Q).
-        Affects the shape envelope.
-        [0 1/A]
-        """,
+    (
+        "Lower bound of the Q-grid for the calculated F(Q)."
+        "  Affects the shape envelope. [0 1/A]"
+    ),
 )
 
 DebyePDFCalculator.qmax = propertyFromExtDoubleAttr(
     "qmax",
-    """Upper bound of the Q-grid for the calculated F(Q).
-        Affects the termination ripples.
-        [25 1/A]
-        """,
+    (
+        "Upper bound of the Q-grid for the calculated F(Q)."
+        "  Affects the termination ripples. [25 1/A]"
+    ),
 )
 
 DebyePDFCalculator.qstep = propertyFromExtDoubleAttr(
     "qstep",
-    """Spacing in the Q-grid.  Q-values are at the multiples of qstep.
-        [PI/extendedrmax A] unless user overridden.
-        See also setOptimumQstep, isOptimumQstep.""",
+    (
+        "Spacing in the Q-grid."
+        "  Q-values are at the multiples of qstep. [PI/extendedrmax A]"
+        " unless user overridden.  See also setOptimumQstep, isOptimumQstep."
+    ),
 )
 
 # method overrides to support optional keyword arguments
@@ -248,7 +249,6 @@ def _init_kwargs0(self, **kwargs):
 
 DebyePDFCalculator.__boostpython__init = DebyePDFCalculator.__init__
 DebyePDFCalculator.__init__ = _init_kwargs0
-
 # End of class DebyePDFCalculator
 
 # PDFCalculator --------------------------------------------------------------
@@ -261,53 +261,62 @@ _defineCommonInterface(PDFCalculator)
 
 PDFCalculator.peakprecision = propertyFromExtDoubleAttr(
     "peakprecision",
-    """Cutoff amplitude of the peak tail relative to the peak maximum.
-        [3.33e-6 unitless]""",
+    (
+        "Cutoff amplitude of the peak tail relative to the peak maximum."
+        " [3.33e-6 unitless]"
+    ),
 )
-
 PDFCalculator.qmin = propertyFromExtDoubleAttr(
     "qmin",
-    """Lower bound of the experimental Q-range used.
-        Affects the shape envelope.
-        [0 1/A]""",
+    (
+        "Lower bound of the experimental Q-range used."
+        "  Affects the shape envelope. [0 1/A]"
+    ),
 )
-
 PDFCalculator.qmax = propertyFromExtDoubleAttr(
     "qmax",
-    """Upper bound of the experimental Q-range used.
-        Affects the termination ripples.  Not used when zero.
-        [0 1/A]""",
+    (
+        "Upper bound of the experimental Q-range used."
+        "  Affects the termination ripples.  Not used when zero. [0 1/A]"
+    ),
 )
-
 PDFCalculator.qstep = propertyFromExtDoubleAttr(
     "qstep",
-    """Spacing in the Q-grid.  Q-values are at the multiples of qstep.
-        The value is padded by rsteps so that PI/qstep > extendedrmax and
-        PI/(qstep * rstep) is a power of 2.  Read-only.
-        [PI/(padded extendedrmax) A]""",
+    (
+        "Spacing in the Q-grid."
+        "  Q-values are at the multiples of qstep. The value is padded"
+        " by rsteps so that PI/qstep > extendedrmax and"
+        " PI/(qstep * rstep) is a power of 2.  Read-only."
+        " [PI/(padded extendedrmax) A]"
+    ),
 )
 
 PDFCalculator.slope = propertyFromExtDoubleAttr(
     "slope",
-    """Slope of the linear PDF background.  Assigned according to
-        number density of the evaluated structure at each PDF calculation.
-        Active for LinearBaseline.
-        [-4*pi*numdensity unitless]""",
+    (
+        "Slope of the linear PDF background."
+        "  Assigned according to number density of the evaluated"
+        " structure at each PDF calculation. Active for LinearBaseline."
+        " [-4*pi*numdensity unitless]"
+    ),
 )
 
 PDFCalculator.spdiameter = propertyFromExtDoubleAttr(
     "spdiameter",
-    """Spherical particle diameter for PDF shape damping correction.
-        Not used when zero.  Active for SphericalShapeEnvelope.
-        [0 A]""",
+    (
+        "Spherical particle diameter for PDF shape damping correction."
+        "  Not used when zero.  Active for SphericalShapeEnvelope. [0 A]"
+    ),
 )
 
 PDFCalculator.stepcut = propertyFromExtDoubleAttr(
     "stepcut",
-    """r-boundary for a step cutoff of the calculated PDF.
-        Not used when negative or zero.  Active for StepCutEnvelope.
-        Not used when zero.  Active for StepCutEnvelope.
-        [0 A]""",
+    (
+        "r-boundary for a step cutoff of the calculated PDF."
+        "  Not used when negative or zero.  Active for StepCutEnvelope."
+        "  Not used when zero.  Active for StepCutEnvelope."
+        " [0 A]"
+    ),
 )
 
 # method overrides to support optional keyword arguments

--- a/src/diffpy/srreal/pdfcalculator.py
+++ b/src/diffpy/srreal/pdfcalculator.py
@@ -18,12 +18,9 @@ Top-level classes for PDF calculation:
     PDFCalculator      -- calculate PDF by peak summation in real space
 """
 
-from diffpy.srreal.srreal_ext import (
-    DebyePDFCalculator as _DebyePDFCalculator,
-    PDFCalculator as _PDFCalculator,
-    fftftog,
-    fftgtof,
-)
+from diffpy.srreal.srreal_ext import DebyePDFCalculator as _DebyePDFCalculator
+from diffpy.srreal.srreal_ext import PDFCalculator as _PDFCalculator
+from diffpy.srreal.srreal_ext import fftftog, fftgtof
 from diffpy.srreal.wraputils import (
     propertyFromExtDoubleAttr,
     setattrFromKeywordArguments,
@@ -195,6 +192,7 @@ def _defineCommonInterface(cls):
 
 # class DebyePDFCalculator ---------------------------------------------------
 
+
 class DebyePDFCalculator(_DebyePDFCalculator):
     __doc__ = _DebyePDFCalculator.__doc__
 
@@ -250,6 +248,7 @@ DebyePDFCalculator.qstep = propertyFromExtDoubleAttr(
 # End of class DebyePDFCalculator
 
 # PDFCalculator --------------------------------------------------------------
+
 
 class PDFCalculator(_PDFCalculator):
     __doc__ = _PDFCalculator.__doc__

--- a/src/diffpy/srreal/pdfcalculator.py
+++ b/src/diffpy/srreal/pdfcalculator.py
@@ -19,8 +19,8 @@ Top-level classes for PDF calculation:
 """
 
 from diffpy.srreal.srreal_ext import (
-    DebyePDFCalculator,
-    PDFCalculator,
+    DebyePDFCalculator as _DebyePDFCalculator,
+    PDFCalculator as _PDFCalculator,
     fftftog,
     fftgtof,
 )
@@ -195,6 +195,23 @@ def _defineCommonInterface(cls):
 
 # class DebyePDFCalculator ---------------------------------------------------
 
+class DebyePDFCalculator(_DebyePDFCalculator):
+    __doc__ = _DebyePDFCalculator.__doc__
+
+    def __init__(self, **kwargs):
+        """Create a new instance of the DebyePDFCalculator.
+        Keyword arguments can be used to configure the calculator properties,
+        for example:
+
+        dpc = DebyePDFCalculator(qmax=20, rmin=7, rmax=15)
+
+        Raise ValueError for invalid keyword argument.
+        """
+        super().__init__()
+        setattrFromKeywordArguments(self, **kwargs)
+        return
+
+
 # shared interface of the PDF calculator classes
 
 _defineCommonInterface(DebyePDFCalculator)
@@ -230,28 +247,26 @@ DebyePDFCalculator.qstep = propertyFromExtDoubleAttr(
     ),
 )
 
-# method overrides to support optional keyword arguments
-
-
-def _init_kwargs0(self, **kwargs):
-    """Create a new instance of the DebyePDFCalculator.
-    Keyword arguments can be used to configure the calculator properties,
-    for example:
-
-    dpc = DebyePDFCalculator(qmax=20, rmin=7, rmax=15)
-
-    Raise ValueError for invalid keyword argument.
-    """
-    DebyePDFCalculator.__boostpython__init(self)
-    setattrFromKeywordArguments(self, **kwargs)
-    return
-
-
-DebyePDFCalculator.__boostpython__init = DebyePDFCalculator.__init__
-DebyePDFCalculator.__init__ = _init_kwargs0
 # End of class DebyePDFCalculator
 
 # PDFCalculator --------------------------------------------------------------
+
+class PDFCalculator(_PDFCalculator):
+    __doc__ = _PDFCalculator.__doc__
+
+    def __init__(self, **kwargs):
+        """Create a new instance of PDFCalculator.
+        Keyword arguments can be used to configure the calculator properties,
+        for example:
+
+        pc = PDFCalculator(qmax=20, rmin=7, rmax=15)
+
+        Raise ValueError for invalid keyword argument.
+        """
+        super().__init__()
+        setattrFromKeywordArguments(self, **kwargs)
+        return
+
 
 # shared interface of the PDF calculator classes
 
@@ -318,26 +333,6 @@ PDFCalculator.stepcut = propertyFromExtDoubleAttr(
         " [0 A]"
     ),
 )
-
-# method overrides to support optional keyword arguments
-
-
-def _init_kwargs1(self, **kwargs):
-    """Create a new instance of PDFCalculator.
-    Keyword arguments can be used to configure the calculator properties,
-    for example:
-
-    pc = PDFCalculator(qmax=20, rmin=7, rmax=15)
-
-    Raise ValueError for invalid keyword argument.
-    """
-    PDFCalculator.__boostpython__init(self)
-    setattrFromKeywordArguments(self, **kwargs)
-    return
-
-
-PDFCalculator.__boostpython__init = PDFCalculator.__init__
-PDFCalculator.__init__ = _init_kwargs1
 
 # End of class PDFCalculator
 

--- a/src/diffpy/srreal/pdfenvelope.py
+++ b/src/diffpy/srreal/pdfenvelope.py
@@ -18,7 +18,6 @@ Classes for configuring PDF scaling envelope:
     SphericalShapeEnvelope, StepCutEnvelope
 """
 
-
 # exported items
 __all__ = """
    PDFEnvelope makePDFEnvelope
@@ -51,26 +50,22 @@ StepCutEnvelope.__getstate_manages_dict__ = None
 
 QResolutionEnvelope.qdamp = propertyFromExtDoubleAttr(
     "qdamp",
-    """Dampening parameter in the Gaussian envelope function.
-    """,
+    "Dampening parameter in the Gaussian envelope function.",
 )
 
 ScaleEnvelope.scale = propertyFromExtDoubleAttr(
     "scale",
-    """Overall scale for a uniform scaling envelope.
-    """,
+    "Overall scale for a uniform scaling envelope.",
 )
 
 SphericalShapeEnvelope.spdiameter = propertyFromExtDoubleAttr(
     "spdiameter",
-    """Particle diameter in Angstroms for a spherical shape damping.
-    """,
+    "Particle diameter in Angstroms for a spherical shape damping.",
 )
 
 StepCutEnvelope.stepcut = propertyFromExtDoubleAttr(
     "stepcut",
-    """Cutoff for a step-function envelope.
-    """,
+    "Cutoff for a step-function envelope.",
 )
 
 # Python functions wrapper

--- a/src/diffpy/srreal/peakprofile.py
+++ b/src/diffpy/srreal/peakprofile.py
@@ -18,7 +18,6 @@ Class for configuring PDF profile function:
     GaussianProfile, CroppedGaussianProfile
 """
 
-
 # exported items
 __all__ = ["PeakProfile", "GaussianProfile", "CroppedGaussianProfile"]
 
@@ -41,9 +40,11 @@ CroppedGaussianProfile.__getstate_manages_dict__ = None
 
 PeakProfile.peakprecision = propertyFromExtDoubleAttr(
     "peakprecision",
-    """Profile amplitude relative to the peak maximum for evaluating peak
-    bounds xboundlo and xboundhi. [3.33e-6 unitless]
-    """,
+    (
+        "Profile amplitude relative to the peak maximum for evaluating "
+        "peak bounds xboundlo and xboundhi.\n\n"
+        "[3.33e-6 unitless]"
+    ),
 )
 
 # Import delayed tweaks of the extension classes.

--- a/src/diffpy/srreal/peakwidthmodel.py
+++ b/src/diffpy/srreal/peakwidthmodel.py
@@ -18,7 +18,6 @@ Classes for configuring peak width evaluation in PDF calculations:
     ConstantPeakWidth, DebyeWallerPeakWidth, JeongPeakWidth
 """
 
-
 # exported items
 __all__ = [
     "PeakWidthModel",
@@ -42,20 +41,17 @@ from diffpy.srreal.wraputils import propertyFromExtDoubleAttr
 
 ConstantPeakWidth.width = propertyFromExtDoubleAttr(
     "width",
-    """Constant FWHM value returned by this model.
-    """,
+    "Constant FWHM value returned by this model.",
 )
 
 ConstantPeakWidth.bisowidth = propertyFromExtDoubleAttr(
     "bisowidth",
-    """Equivalent uniform Biso for this constant `width`.
-    """,
+    "Equivalent uniform Biso for this constant `width`.",
 )
 
 ConstantPeakWidth.uisowidth = propertyFromExtDoubleAttr(
     "uisowidth",
-    """Equivalent uniform Uiso for this constant `width`.
-    """,
+    "Equivalent uniform Uiso for this constant `width`.",
 )
 
 JeongPeakWidth.delta1 = propertyFromExtDoubleAttr(

--- a/src/diffpy/srreal/scatteringfactortable.py
+++ b/src/diffpy/srreal/scatteringfactortable.py
@@ -15,7 +15,6 @@
 """Class ScatteringFactorTable -- scattering factors for atoms, ions and
 isotopes."""
 
-
 # exported items, these also makes them show in pydoc.
 __all__ = [
     "ScatteringFactorTable",

--- a/src/diffpy/srreal/sfaverage.py
+++ b/src/diffpy/srreal/sfaverage.py
@@ -33,7 +33,6 @@ Examples
                                      dpdfc.scatteringfactortable, dpdfc.qgrid)
 """
 
-
 # class SFAverage ------------------------------------------------------------
 
 

--- a/src/diffpy/srreal/structureconverters.py
+++ b/src/diffpy/srreal/structureconverters.py
@@ -125,16 +125,22 @@ class _DiffPyStructureMetadata(object):
 
 # end of class _DiffPyStructureMetadata
 
+def _installDiffPyStructureMetadata(cls):
+    """Install diffpy.structure metadata hooks without multiple inheritance."""
+    cls.pdffit = _DiffPyStructureMetadata.pdffit
+    cls.hasMetadata = staticmethod(_DiffPyStructureMetadata.hasMetadata)
+    cls._customPQConfig = _DiffPyStructureMetadata._customPQConfig
+    cls._fetchMetadata = _DiffPyStructureMetadata._fetchMetadata
+    return cls
 
-class DiffPyStructureAtomicAdapter(
-    _DiffPyStructureMetadata, AtomicStructureAdapter
-):
+
+@_installDiffPyStructureMetadata
+class DiffPyStructureAtomicAdapter(AtomicStructureAdapter):
     pass
 
 
-class DiffPyStructurePeriodicAdapter(
-    _DiffPyStructureMetadata, PeriodicStructureAdapter
-):
+@_installDiffPyStructureMetadata
+class DiffPyStructurePeriodicAdapter(PeriodicStructureAdapter):
     pass
 
 
@@ -153,7 +159,7 @@ def _fetchDiffPyStructureData(adpt, stru):
     from diffpy.srreal.srreal_ext import Atom as AdapterAtom
 
     # copy atoms
-    del adpt[:]
+    adpt.clear()
     adpt.reserve(len(stru))
     aa = AdapterAtom()
     for a0 in stru:

--- a/src/diffpy/srreal/structureconverters.py
+++ b/src/diffpy/srreal/structureconverters.py
@@ -125,8 +125,10 @@ class _DiffPyStructureMetadata(object):
 
 # end of class _DiffPyStructureMetadata
 
+
 def _installDiffPyStructureMetadata(cls):
-    """Install diffpy.structure metadata hooks without multiple inheritance."""
+    """Install diffpy.structure metadata hooks without multiple
+    inheritance."""
     cls.pdffit = _DiffPyStructureMetadata.pdffit
     cls.hasMetadata = staticmethod(_DiffPyStructureMetadata.hasMetadata)
     cls._customPQConfig = _DiffPyStructureMetadata._customPQConfig

--- a/src/diffpy/srreal/wraputils.py
+++ b/src/diffpy/srreal/wraputils.py
@@ -15,7 +15,6 @@
 """Local utilities helpful for tweaking interfaces to boost python
 classes."""
 
-
 import copy
 
 # Routines -------------------------------------------------------------------
@@ -111,9 +110,10 @@ def _wrapAsRegisteredUnaryFunction(
             return copy.copy(self)
 
         def type(self):
-            """Unique string identifier of this functor type.  The
-            string is used for class registration and as an argument for
-            the createByType function.
+            """Unique string identifier of this functor type.
+
+            The string is used for class registration and as an argument
+            for the createByType function.
 
             Return string identifier.
             """

--- a/src/extensions/srreal_converters.cpp
+++ b/src/extensions/srreal_converters.cpp
@@ -17,15 +17,13 @@
 *
 *****************************************************************************/
 
-#include <boost/python/slice.hpp>
-#include <boost/python/stl_iterator.hpp>
-#include <boost/python/exception_translator.hpp>
+// TODO: replace Py_DECREF with nb::steal
 
 #include <string>
-#include <valarray>
 #include <stdexcept>
 #include <cassert>
 #include <cstdlib>
+#include <ranges>
 
 #include <diffpy/Attributes.hpp>
 #include <diffpy/srreal/StructureAdapter.hpp>
@@ -60,18 +58,26 @@ void translate_invalid_argument(const invalid_argument& e)
 }
 
 
-boost::python::object newNumPyArray(int dim, const int* sz, int typenum)
+nb::object newNumPyArray(int dim, const int* sz, int typenum)
 {
-    using namespace std;
-    using namespace boost;
-    // copy the size information to an array of npy_intp
-    valarray<npy_intp> npsza(dim);
-    npy_intp& npsz = npsza[0];
-    copy(sz, sz + dim, &npsz);
-    // create numpy array
-    python::object rv(
-            python::handle<>(PyArray_SimpleNew(dim, &npsz, typenum)));
-    return rv;
+    std::vector<npy_intp> dims(static_cast<size_t>(dim));
+    std::transform(
+        sz,
+        sz + dim,
+        dims.begin(),
+        [](int v) { return static_cast<npy_intp>(v); }
+    );
+    
+    PyObject *arr = PyArray_SimpleNew(
+        dim,
+        dims.empty() ? nullptr : dims.data(),
+        typenum
+    );
+
+    if (!arr)
+        throw nb::python_error();
+    
+    return nb::steal<nb::object>(arr);
 }
 
 }   // namespace
@@ -81,18 +87,31 @@ namespace srrealmodule {
 /// this function registers all exception translators
 void wrap_exceptions()
 {
-    using boost::python::register_exception_translator;
-    register_exception_translator<DoubleAttributeError>(
-            &translate_DoubleAttributeError);
-    register_exception_translator<invalid_argument>(
-            &translate_invalid_argument);
+    nb::register_exception_translator(
+        [](const std::exception_ptr& p, void*) 
+        {
+            try 
+            {
+                if (p)
+                    std::rethrow_exception(p);
+            } 
+            catch (const DoubleAttributeError& e) 
+            {
+                PyErr_SetString(PyExc_AttributeError, e.what());
+            } 
+            catch (const invalid_argument& e) 
+            {
+                PyErr_SetString(PyExc_ValueError, e.what());
+            }
+        }
+    );
 }
 
 
 /// helper for creating numpy array of doubles
 NumPyArray_DoublePtr createNumPyDoubleArray(int dim, const int* sz)
 {
-    boost::python::object rvobj = newNumPyArray(dim, sz, NPY_DOUBLE);
+    nb::object rvobj = newNumPyArray(dim, sz, NPY_DOUBLE);
     PyArrayObject* a = reinterpret_cast<PyArrayObject*>(rvobj.ptr());
     double* rvdata = static_cast<double*>(PyArray_DATA(a));
     NumPyArray_DoublePtr rv(rvobj, rvdata);
@@ -101,15 +120,22 @@ NumPyArray_DoublePtr createNumPyDoubleArray(int dim, const int* sz)
 
 
 /// helper for creating numpy array of the same shape as the argument
-NumPyArray_DoublePtr createNumPyDoubleArrayLike(boost::python::object& obj)
+NumPyArray_DoublePtr createNumPyDoubleArrayLike(nb::object& obj)
 {
     assert(PyArray_Check(obj.ptr()));
     PyArrayObject* a = reinterpret_cast<PyArrayObject*>(obj.ptr());
     // create numpy array
-    boost::python::object rvobj(
-            boost::python::handle<>(
-                PyArray_NewLikeArray(
-                    a, NPY_CORDER, PyArray_DescrFromType(NPY_DOUBLE), 0)));
+    PyObject *pobj = PyArray_NewLikeArray(
+        a,
+        NPY_CORDER,
+        PyArray_DescrFromType(NPY_DOUBLE),
+        0
+    );
+
+    if (!pobj)
+        throw nb::python_error();
+
+    nb::object rvobj = nb::steal<nb::object>(pobj);
     PyArrayObject* a1 = reinterpret_cast<PyArrayObject*>(rvobj.ptr());
     double* rvdata = static_cast<double*>(PyArray_DATA(a1));
     NumPyArray_DoublePtr rv(rvobj, rvdata);
@@ -118,23 +144,33 @@ NumPyArray_DoublePtr createNumPyDoubleArrayLike(boost::python::object& obj)
 
 
 /// helper for creating a numpy array view on a double array
-boost::python::object
+nb::object
 createNumPyDoubleView(double* data, int dim, const int* sz)
 {
-    using namespace std;
-    using namespace boost;
-    valarray<npy_intp> npsza(dim);
-    npy_intp* npsz = &(npsza[0]);
-    copy(sz, sz + dim, npsz);
-    python::object rv(
-            python::handle<>(
-                PyArray_SimpleNewFromData(dim, npsz, NPY_DOUBLE, data)));
-    return rv;
+    std::vector<npy_intp> dims(static_cast<size_t>(dim));
+    std::transform(
+        sz,
+        sz + dim,
+        dims.begin(),
+        [](int v) { return static_cast<npy_intp>(v); }
+    );
+
+    PyObject* pobj = PyArray_SimpleNewFromData(
+        dim,
+        dims.data(),
+        NPY_DOUBLE,
+        data
+    );
+
+    if (!pobj)
+        throw nb::python_error();
+
+    return nb::steal<nb::object>(pobj);
 }
 
 
 /// NumPy array view specializations for R3::Vector
-boost::python::object viewAsNumPyArray(::diffpy::srreal::R3::Vector& v)
+nb::object viewAsNumPyArray(::diffpy::srreal::R3::Vector& v)
 {
     using namespace diffpy::srreal;
     double* data = &(v[0]);
@@ -144,7 +180,7 @@ boost::python::object viewAsNumPyArray(::diffpy::srreal::R3::Vector& v)
 
 
 /// NumPy array view specializations for R3::Matrix
-boost::python::object viewAsNumPyArray(::diffpy::srreal::R3::Matrix& mx)
+nb::object viewAsNumPyArray(::diffpy::srreal::R3::Matrix& mx)
 {
     using namespace diffpy::srreal;
     double* data = &(mx(0, 0));
@@ -155,9 +191,8 @@ boost::python::object viewAsNumPyArray(::diffpy::srreal::R3::Matrix& mx)
 
 /// Copy NumPy array to R3::Vector
 void assignR3Vector(
-        ::diffpy::srreal::R3::Vector& dst, boost::python::object& value)
+        ::diffpy::srreal::R3::Vector& dst, nb::object& value)
 {
-    using namespace boost;
     using diffpy::srreal::R3::Ndim;
     // If value is numpy array, try direct data access
     if (PyArray_Check(value.ptr()))
@@ -167,30 +202,29 @@ void assignR3Vector(
         if (a && Ndim == PyArray_DIM(a, 0))
         {
             double* p = static_cast<double*>(PyArray_DATA(a));
-            std::copy(p, p + Ndim, dst.data().begin());
+            std::ranges::copy(p, p + Ndim, dst.data().begin());
             Py_DECREF(a);
             return;
         }
         Py_XDECREF(a);
     }
     // handle scalar assignment
-    python::extract<double> getvalue(value);
-    if (getvalue.check())
+    double scalar;
+    if (nb::try_cast<double>(value, scalar))
     {
-        std::fill(dst.data().begin(), dst.data().end(), getvalue());
+        std::ranges::fill(dst.data().begin(), dst.data().end(), scalar);
         return;
     }
     // finally assign using array view
-    python::object dstview = viewAsNumPyArray(dst);
-    dstview[python::slice()] = value;
+    nb::object dstview = viewAsNumPyArray(dst);
+    dstview[nb::slice(nb::none(), nb::none(), nb::none())] = value;
 }
 
 
 /// Copy possible NumPy array to R3::Matrix
 void assignR3Matrix(
-        ::diffpy::srreal::R3::Matrix& dst, boost::python::object& value)
+        ::diffpy::srreal::R3::Matrix& dst, nb::object& value)
 {
-    using namespace boost;
     using diffpy::srreal::R3::Ndim;
     // If value is numpy array, try direct data access
     if (PyArray_Check(value.ptr()))
@@ -200,29 +234,29 @@ void assignR3Matrix(
         if (a && Ndim == PyArray_DIM(a, 0) && Ndim == PyArray_DIM(a, 1))
         {
             double* p = static_cast<double*>(PyArray_DATA(a));
-            std::copy(p, p + Ndim * Ndim, dst.data().begin());
+            std::ranges::copy(p, p + Ndim * Ndim, dst.data().begin());
             Py_DECREF(a);
             return;
         }
         Py_XDECREF(a);
     }
     // handle scalar assignment
-    python::extract<double> getvalue(value);
-    if (getvalue.check())
+    double scalar;
+    if (nb::try_cast<double>(value, scalar))
     {
-        std::fill(dst.data().begin(), dst.data().end(), getvalue());
+        std::ranges::fill(dst.data().begin(), dst.data().end(), scalar);
         return;
     }
     // finally assign using array view
-    python::object dstview = viewAsNumPyArray(dst);
-    dstview[python::slice()] = value;
+    nb::object dstview = viewAsNumPyArray(dst);
+    dstview[nb::slice(nb::none(), nb::none(), nb::none())] = value;
 }
 
 
 /// helper for creating numpy array of integers
 NumPyArray_IntPtr createNumPyIntArray(int dim, const int* sz)
 {
-    boost::python::object rvobj = newNumPyArray(dim, sz, NPY_INT);
+    nb::object rvobj = newNumPyArray(dim, sz, NPY_INT);
     PyArrayObject* a = reinterpret_cast<PyArrayObject*>(rvobj.ptr());
     int* rvdata = static_cast<int*>(PyArray_DATA(a));
     NumPyArray_IntPtr rv(rvobj, rvdata);
@@ -233,14 +267,14 @@ NumPyArray_IntPtr createNumPyIntArray(int dim, const int* sz)
 /// efficient conversion of Python object to a QuantityType
 diffpy::srreal::QuantityType&
 extractQuantityType(
-        boost::python::object obj,
+        nb::object obj,
         diffpy::srreal::QuantityType& rv)
 {
-    using namespace boost;
     using diffpy::srreal::QuantityType;
     // extract QuantityType directly
-    python::extract<QuantityType&> getqt(obj);
-    if (getqt.check())  return getqt();
+    QuantityType* qt = nullptr;
+    if (nb::try_cast<QuantityType*>(obj, qt) && qt)
+        return *qt;
     // copy data directly if it is a numpy array of doubles
     PyArrayObject* a = PyArray_Check(obj.ptr()) ?
         reinterpret_cast<PyArrayObject*>(obj.ptr()) : NULL;
@@ -257,24 +291,38 @@ extractQuantityType(
         return rv;
     }
     // otherwise copy elementwise converting each element to a double
-    python::stl_input_iterator<double> begin(obj), end;
-    rv.assign(begin, end);
+    std::vector<double> tmp;
+
+    PyObject* iter = PyObject_GetIter(obj.ptr());
+    if (!iter)
+        throw nb::python_error();
+
+    nb::object it = nb::steal<nb::object>(iter);
+
+    while (PyObject* item = PyIter_Next(it.ptr())) 
+    {
+        nb::object item_obj = nb::steal<nb::object>(item);
+        tmp.push_back(nb::cast<double>(item_obj));
+    }
+
+    if (PyErr_Occurred())
+        throw nb::python_error();
+
+    rv.assign(tmp.begin(), tmp.end());
     return rv;
 }
 
 
 /// efficient conversion of Python object to a numpy array of doubles
-NumPyArray_DoublePtr extractNumPyDoubleArray(::boost::python::object& obj)
+NumPyArray_DoublePtr extractNumPyDoubleArray(::nb::object& obj)
 {
     PyObject* pobj = PyArray_ContiguousFromAny(obj.ptr(), NPY_DOUBLE, 0, 0);
     if (!pobj)
     {
-        const char* emsg = "Cannot convert this object to numpy array.";
-        PyErr_SetString(PyExc_TypeError, emsg);
-        boost::python::throw_error_already_set();
-        abort();
+        PyErr_Clear();
+        throw nb::type_error("Cannot convert this object to numpy array.");
     }
-    boost::python::object rvobj((boost::python::handle<>(pobj)));
+    nb::object rvobj = nb::steal<nb::object>(pobj);
     PyArrayObject* a = reinterpret_cast<PyArrayObject*>(pobj);
     double* rvdata = static_cast<double*>(PyArray_DATA(a));
     NumPyArray_DoublePtr rv(rvobj, rvdata);
@@ -283,46 +331,55 @@ NumPyArray_DoublePtr extractNumPyDoubleArray(::boost::python::object& obj)
 
 
 /// extract double with a support for numpy.int types
-double extractdouble(boost::python::object obj)
+double extractdouble(nb::object obj)
 {
-    using namespace boost;
-    python::extract<double> getx(obj);
-    if (getx.check())  return getx();
+    double x;
+    if (nb::try_cast<double>(obj, x))
+        return x;
+
     PyObject* pobj = obj.ptr();
     if (PyArray_CheckScalar(pobj))
     {
-        double x;
-        PyArray_CastScalarToCtype(pobj, &x,
-                PyArray_DescrFromType(NPY_DOUBLE));
+        PyArray_Descr* descr = PyArray_DescrFromType(NPY_DOUBLE);
+        if (!descr)
+            throw nb::python_error();
+
+        int ok = PyArray_CastScalarToCtype(pobj, &x, descr);
+        Py_DECREF(descr);
+
+        if (ok < 0)
+            throw nb::python_error();
+
         return x;
     }
-    // nothing worked, call getx which will raise an exception
-    return getx();
+    // nothing worked, call default behavior which will raise an exception
+    return nb::cast<double>(obj);
 }
 
 
 /// extract integer with a support for numpy.int types
-int extractint(boost::python::object obj)
+int extractint(nb::object obj)
 {
-    using namespace boost;
-    python::extract<int> geti(obj);
-    if (geti.check())  return geti();
+    int i;
+    if (nb::try_cast<int>(obj, i))
+        return i;
+
     PyObject* pobj = obj.ptr();
     if (PyArray_CheckScalar(pobj))
     {
         int rv = PyArray_PyIntAsInt(pobj);
-        if (rv == -1 && PyErr_Occurred())  python::throw_error_already_set();
+        if (rv == -1 && PyErr_Occurred())
+            throw nb::python_error();
         return rv;
     }
-    // nothing worked, call geti which will raise an exception
-    return geti();
+    // nothing worked, call default behavior which will raise an exception
+    return nb::cast<int>(obj);
 }
 
 
 /// extract a vector of integers from a numpy array, iterable or scalar
-std::vector<int> extractintvector(boost::python::object obj)
+std::vector<int> extractintvector(nb::object obj)
 {
-    using namespace boost::python;
     std::vector<int> rv;
     // iterable of integers
     if (isiterable(obj))
@@ -334,11 +391,14 @@ std::vector<int> extractintvector(boost::python::object obj)
             a && (1 == PyArray_NDIM(a)) && PyArray_ISINTEGER(a);
         if (isintegernumpyarray)
         {
-            object aobj = obj;
+            nb::object aobj = obj;
             if (NPY_INT != PyArray_TYPE(a))
             {
-                object a1(handle<>(PyArray_Cast(a, NPY_INT)));
-                aobj = a1;
+                PyObject* casted = PyArray_Cast(a, NPY_INT);
+                if (!casted)
+                    throw nb::python_error();
+
+                aobj = nb::steal<nb::object>(casted);
             }
             PyArrayObject* a1 = reinterpret_cast<PyArrayObject*>(aobj.ptr());
             assert(NPY_INT == PyArray_TYPE(a1));
@@ -348,13 +408,11 @@ std::vector<int> extractintvector(boost::python::object obj)
             return rv;
         }
         // otherwise translate every item in the iterable
-        stl_input_iterator<object> ii(obj), end;
         rv.reserve(len(obj));
-        for (; ii != end; ++ii)
-        {
-            int idx = extractint(*ii);
-            rv.push_back(idx);
-        }
+
+        for (nb::handle item : obj)
+            rv.push_back(extractint(nb::borrow<nb::object>(item)));
+
         return rv;
     }
     // try to handle it as a scalar
@@ -370,8 +428,7 @@ void throwPureVirtualCalled(const char* fncname)
     std::string emsg = "Pure virtual function '";
     emsg += fncname;
     emsg += "' called.";
-    PyErr_SetString(PyExc_RuntimeError, emsg.c_str());
-    boost::python::throw_error_already_set();
+    throw std::runtime_error(emsg);
 }
 
 }   // namespace srrealmodule
@@ -382,19 +439,15 @@ namespace srreal {
 
 /// shared converter that first tries to extract the pointer and then calls
 /// diffpy.srreal.structureadapter.createStructureAdapter
-StructureAdapterPtr createStructureAdapter(::boost::python::object stru)
+StructureAdapterPtr createStructureAdapter(nb::object stru)
 {
-    using namespace boost::python;
     StructureAdapterPtr adpt;
-    extract<StructureAdapterPtr> getadpt(stru);
-    if (getadpt.check())  adpt = getadpt();
-    else
-    {
-        object mod = import("diffpy.srreal.structureadapter");
-        object convertinpython = mod.attr("createStructureAdapter");
-        adpt = extract<StructureAdapterPtr>(convertinpython(stru));
-    }
-    return adpt;
+    if (nb::try_cast<StructureAdapterPtr>(stru, adpt))
+        return adpt;
+
+    nb::object mod = nb::module_::import_("diffpy.srreal.structureadapter");
+    nb::object convertinpython = mod.attr("createStructureAdapter");
+    return nb::cast<StructureAdapterPtr>(convertinpython(stru));
 }
 
 }   // namespace srreal

--- a/src/extensions/srreal_converters.cpp
+++ b/src/extensions/srreal_converters.cpp
@@ -23,6 +23,7 @@
 #include <stdexcept>
 #include <cassert>
 #include <cstdlib>
+#include <limits>
 #include <ranges>
 
 #include <diffpy/Attributes.hpp>
@@ -360,10 +361,6 @@ double extractdouble(nb::object obj)
 /// extract integer with a support for numpy.int types
 int extractint(nb::object obj)
 {
-    int i;
-    if (nb::try_cast<int>(obj, i))
-        return i;
-
     PyObject* pobj = obj.ptr();
     if (PyArray_CheckScalar(pobj))
     {
@@ -372,8 +369,24 @@ int extractint(nb::object obj)
             throw nb::python_error();
         return rv;
     }
-    // nothing worked, call default behavior which will raise an exception
-    return nb::cast<int>(obj);
+
+    PyObject* idx = PyNumber_Index(pobj);
+    if (!idx)
+        throw nb::python_error();
+
+    nb::object idx_obj = nb::steal<nb::object>(idx);
+    long value = PyLong_AsLong(idx_obj.ptr());
+    if (value == -1 && PyErr_Occurred())
+        throw nb::python_error();
+
+    if (value < std::numeric_limits<int>::min() ||
+            value > std::numeric_limits<int>::max())
+    {
+        PyErr_SetString(PyExc_OverflowError, "integer index out of range");
+        throw nb::python_error();
+    }
+
+    return static_cast<int>(value);
 }
 
 

--- a/src/extensions/srreal_converters.cpp
+++ b/src/extensions/srreal_converters.cpp
@@ -68,7 +68,7 @@ nb::object newNumPyArray(int dim, const int* sz, int typenum)
         dims.begin(),
         [](int v) { return static_cast<npy_intp>(v); }
     );
-    
+
     PyObject *arr = PyArray_SimpleNew(
         dim,
         dims.empty() ? nullptr : dims.data(),
@@ -77,7 +77,7 @@ nb::object newNumPyArray(int dim, const int* sz, int typenum)
 
     if (!arr)
         throw nb::python_error();
-    
+
     return nb::steal<nb::object>(arr);
 }
 
@@ -89,18 +89,18 @@ namespace srrealmodule {
 void wrap_exceptions()
 {
     nb::register_exception_translator(
-        [](const std::exception_ptr& p, void*) 
+        [](const std::exception_ptr& p, void*)
         {
-            try 
+            try
             {
                 if (p)
                     std::rethrow_exception(p);
-            } 
-            catch (const DoubleAttributeError& e) 
+            }
+            catch (const DoubleAttributeError& e)
             {
                 PyErr_SetString(PyExc_AttributeError, e.what());
-            } 
-            catch (const invalid_argument& e) 
+            }
+            catch (const invalid_argument& e)
             {
                 PyErr_SetString(PyExc_ValueError, e.what());
             }
@@ -300,7 +300,7 @@ extractQuantityType(
 
     nb::object it = nb::steal<nb::object>(iter);
 
-    while (PyObject* item = PyIter_Next(it.ptr())) 
+    while (PyObject* item = PyIter_Next(it.ptr()))
     {
         nb::object item_obj = nb::steal<nb::object>(item);
         tmp.push_back(nb::cast<double>(item_obj));

--- a/src/extensions/srreal_converters.hpp
+++ b/src/extensions/srreal_converters.hpp
@@ -24,6 +24,7 @@
 #define SRREAL_CONVERTERS_HPP_INCLUDED
 
 #include <nanobind/nanobind.h>
+#include <nanobind/stl/string.h>
 
 #include <algorithm>
 #include <string>
@@ -373,7 +374,7 @@ convertToPythonDict(const T& value)
 {
     nb::dict rv;
     for (auto const& item : value)
-        rv[item.first] = item.second;
+        rv[nb::cast(item.first)] = nb::cast(item.second);
     return rv;
 }
 

--- a/src/extensions/srreal_converters.hpp
+++ b/src/extensions/srreal_converters.hpp
@@ -25,6 +25,7 @@
 
 #include <nanobind/nanobind.h>
 #include <nanobind/stl/string.h>
+#include <nanobind/stl/shared_ptr.h>
 
 #include <algorithm>
 #include <string>

--- a/src/extensions/srreal_converters.hpp
+++ b/src/extensions/srreal_converters.hpp
@@ -17,6 +17,9 @@
 *
 *****************************************************************************/
 
+// TODO: Go through type casters, some of which are found redundant or could be
+// replaced with nanobind builtins.
+
 #ifndef SRREAL_CONVERTERS_HPP_INCLUDED
 #define SRREAL_CONVERTERS_HPP_INCLUDED
 

--- a/src/extensions/srreal_converters.hpp
+++ b/src/extensions/srreal_converters.hpp
@@ -20,11 +20,7 @@
 #ifndef SRREAL_CONVERTERS_HPP_INCLUDED
 #define SRREAL_CONVERTERS_HPP_INCLUDED
 
-#include <boost/python/object.hpp>
-#include <boost/python/import.hpp>
-#include <boost/python/list.hpp>
-#include <boost/python/dict.hpp>
-#include <boost/python/override.hpp>
+#include <nanobind/nanobind.h>
 
 #include <algorithm>
 #include <string>
@@ -38,6 +34,8 @@
 #error diffpy.srreal requires libdiffpy 1.4.0 or later.
 #endif
 
+namespace nb = nanobind;
+
 /// Conversion function that supports implicit conversions in
 /// PairQuantity::eval and PairQuantity::setStructure
 
@@ -45,7 +43,7 @@ namespace diffpy {
 namespace srreal {
 
 StructureAdapterPtr
-createStructureAdapter(::boost::python::object);
+createStructureAdapter(nb::object);
 
 }   // namespace srreal
 }   // namespace diffpy
@@ -58,16 +56,13 @@ using diffpy::srreal::createStructureAdapter;
 /// either instance or a type string
 #define DECLARE_BYTYPE_SETTER_WRAPPER(method, wrapper) \
     template <class T, class V> \
-    void wrapper(T& obj, ::boost::python::object value) \
+    void wrapper(T& obj, nb::object value) \
     { \
-        using ::boost::python::extract; \
-        extract<std::string> tp(value); \
-        if (tp.check())  obj.method##ByType(tp()); \
-        else \
-        { \
-            typename V::SharedPtr p = extract<typename V::SharedPtr>(value); \
-            obj.method(p); \
-        } \
+        std::string tp;                                       \
+        if (nb::try_cast<std::string>(value, tp))             \
+            obj.method##ByType(tp);                           \
+        else                                                  \
+            obj.method(nb::cast<typename V::SharedPtr>(value)); \
     } \
 
 
@@ -75,9 +70,9 @@ using diffpy::srreal::createStructureAdapter;
 /// that converts the result to numpy array
 #define DECLARE_PYARRAY_METHOD_WRAPPER(method, wrapper) \
     template <class T> \
-    ::boost::python::object wrapper(const T& obj) \
+    nb::object wrapper(const T& obj) \
     { \
-        ::boost::python::object rv = convertToNumPyArray(obj.method()); \
+        nb::object rv = convertToNumPyArray(obj.method()); \
         return rv; \
     } \
 
@@ -86,9 +81,9 @@ using diffpy::srreal::createStructureAdapter;
 /// that converts the result to numpy array
 #define DECLARE_PYARRAY_METHOD_WRAPPER1(method, wrapper) \
     template <class T, class T1> \
-    ::boost::python::object wrapper(const T& obj, const T1& a1) \
+    nb::object wrapper(const T& obj, const T1& a1) \
     { \
-        ::boost::python::object rv = convertToNumPyArray(obj.method(a1)); \
+        nb::object rv = convertToNumPyArray(obj.method(a1)); \
         return rv; \
     } \
 
@@ -97,12 +92,12 @@ using diffpy::srreal::createStructureAdapter;
 /// that converts the result to numpy character array
 #define DECLARE_PYCHARARRAY_METHOD_WRAPPER(method, wrapper) \
     template <class T> \
-    ::boost::python::object wrapper(const T& obj) \
+    nb::object wrapper(const T& obj) \
     { \
-        ::boost::python::list lst = convertToPythonList(obj.method()); \
-        ::boost::python::object tochararray = \
-            ::boost::python::import("numpy").attr("char").attr("array"); \
-        ::boost::python::object rv = tochararray(lst); \
+        nb::list lst = convertToPythonList(obj.method()); \
+        nb::object tochararray = \
+            nb::module_::import_("numpy").attr("char").attr("array"); \
+        nb::object rv = tochararray(lst); \
         return rv; \
     } \
 
@@ -111,9 +106,9 @@ using diffpy::srreal::createStructureAdapter;
 /// that converts the result to a python set
 #define DECLARE_PYSET_METHOD_WRAPPER(method, wrapper) \
     template <class T> \
-    ::boost::python::object wrapper(const T& obj) \
+    nb::object wrapper(const T& obj) \
     { \
-        ::boost::python::object rv = convertToPythonSet(obj.method()); \
+        nb::object rv = convertToPythonSet(obj.method()); \
         return rv; \
     } \
 
@@ -122,9 +117,9 @@ using diffpy::srreal::createStructureAdapter;
 /// that converts the result to a python set
 #define DECLARE_PYSET_METHOD_WRAPPER1(method, wrapper) \
     template <class T, class T1> \
-    ::boost::python::object wrapper(const T& obj, const T1& a1) \
+    nb::object wrapper(const T& obj, const T1& a1) \
     { \
-        ::boost::python::object rv = convertToPythonSet(obj.method(a1)); \
+        nb::object rv = convertToPythonSet(obj.method(a1)); \
         return rv; \
     } \
 
@@ -132,9 +127,9 @@ using diffpy::srreal::createStructureAdapter;
 /// this macro defines a wrapper for C++ function without arguments
 /// that converts the result to a python set
 #define DECLARE_PYSET_FUNCTION_WRAPPER(fnc, wrapper) \
-    ::boost::python::object wrapper() \
+    nb::object wrapper() \
     { \
-        ::boost::python::object rv = convertToPythonSet(fnc()); \
+        nb::object rv = convertToPythonSet(fnc()); \
         return rv; \
     } \
 
@@ -143,9 +138,9 @@ using diffpy::srreal::createStructureAdapter;
 /// that converts the result to a python list
 #define DECLARE_PYLIST_METHOD_WRAPPER(method, wrapper) \
     template <class T> \
-    ::boost::python::object wrapper(const T& obj) \
+    nb::object wrapper(const T& obj) \
     { \
-        ::boost::python::object rv = convertToPythonList(obj.method()); \
+        nb::object rv = convertToPythonList(obj.method()); \
         return rv; \
     } \
 
@@ -154,9 +149,9 @@ using diffpy::srreal::createStructureAdapter;
 /// that convert the result to python list
 #define DECLARE_PYLIST_METHOD_WRAPPER1(method, wrapper) \
     template <class T, class T1> \
-    ::boost::python::object wrapper(const T& obj, const T1& a1) \
+    nb::object wrapper(const T& obj, const T1& a1) \
     { \
-        ::boost::python::object rv = convertToPythonList(obj.method(a1)); \
+        nb::object rv = convertToPythonList(obj.method(a1)); \
         return rv; \
     } \
 
@@ -165,9 +160,9 @@ using diffpy::srreal::createStructureAdapter;
 /// that converts the result to a python list of NumPy arrays
 #define DECLARE_PYLISTARRAY_METHOD_WRAPPER(method, wrapper) \
     template <class T> \
-    ::boost::python::list wrapper(const T& obj) \
+    nb::list wrapper(const T& obj) \
     { \
-        ::boost::python::list rvlist; \
+        nb::list rvlist; \
         fillPyListWithArrays(rvlist, obj.method()); \
         return rvlist; \
     } \
@@ -177,9 +172,9 @@ using diffpy::srreal::createStructureAdapter;
 /// that converts the result to a list of Python sets
 #define DECLARE_PYLISTSET_METHOD_WRAPPER(method, wrapper) \
     template <class T> \
-    ::boost::python::list wrapper(const T& obj) \
+    nb::list wrapper(const T& obj) \
     { \
-        ::boost::python::list rvlist; \
+        nb::list rvlist; \
         fillPyListWithSets(rvlist, obj.method()); \
         return rvlist; \
     } \
@@ -189,9 +184,9 @@ using diffpy::srreal::createStructureAdapter;
 /// that converts the result to a python dict
 #define DECLARE_PYDICT_METHOD_WRAPPER(method, wrapper) \
     template <class T> \
-    ::boost::python::object wrapper(const T& obj) \
+    nb::object wrapper(const T& obj) \
     { \
-        ::boost::python::object rv = convertToPythonDict(obj.method()); \
+        nb::object rv = convertToPythonDict(obj.method()); \
         return rv; \
     } \
 
@@ -200,16 +195,16 @@ using diffpy::srreal::createStructureAdapter;
 /// that converts the result to a python dict
 #define DECLARE_PYDICT_METHOD_WRAPPER1(method, wrapper) \
     template <class T, class T1> \
-    ::boost::python::object wrapper(const T& obj, const T1& a1) \
+    nb::object wrapper(const T& obj, const T1& a1) \
     { \
-        ::boost::python::object rv = convertToPythonDict(obj.method(a1)); \
+        nb::object rv = convertToPythonDict(obj.method(a1)); \
         return rv; \
     } \
 
 
 /// helper template function for DECLARE_PYLISTARRAY_METHOD_WRAPPER
 template <class T>
-void fillPyListWithArrays(::boost::python::list lst, const T& value)
+void fillPyListWithArrays(nb::list lst, const T& value)
 {
     typename T::const_iterator v = value.begin();
     for (; v != value.end(); ++v)  lst.append(convertToNumPyArray(*v));
@@ -218,21 +213,19 @@ void fillPyListWithArrays(::boost::python::list lst, const T& value)
 
 /// template function for converting C++ STL container to a python set
 template <class T>
-::boost::python::object
+nb::object
 convertToPythonSet(const T& value)
 {
-    using namespace ::boost;
-    python::object rvset(python::handle<>(PySet_New(NULL)));
-    python::object rvset_add = rvset.attr("add");
-    typename T::const_iterator ii;
-    for (ii = value.begin(); ii != value.end(); ++ii)  rvset_add(*ii);
-    return rvset;
+    nb::set rv;
+    for (auto const& item : value)
+        rv.add(item);
+    return rv;
 }
 
 
 /// helper template function for DECLARE_PYLISTSET_METHOD_WRAPPER
 template <class T>
-void fillPyListWithSets(::boost::python::list lst, const T& value)
+void fillPyListWithSets(nb::list lst, const T& value)
 {
     typename T::const_iterator v = value.begin();
     for (; v != value.end(); ++v)  lst.append(convertToPythonSet(*v));
@@ -240,7 +233,7 @@ void fillPyListWithSets(::boost::python::list lst, const T& value)
 
 
 /// Type for numpy array object and a raw pointer to its double data
-typedef std::pair<boost::python::object, double*> NumPyArray_DoublePtr;
+typedef std::pair<nb::object, double*> NumPyArray_DoublePtr;
 
 
 /// helper for creating numpy array of doubles
@@ -248,16 +241,16 @@ NumPyArray_DoublePtr createNumPyDoubleArray(int dim, const int* sz);
 
 
 /// helper for creating numpy array of the same shape as the argument
-NumPyArray_DoublePtr createNumPyDoubleArrayLike(boost::python::object& obj);
+NumPyArray_DoublePtr createNumPyDoubleArrayLike(nb::object& obj);
 
 
 /// helper for creating numpy views on existing double array
-boost::python::object createNumPyDoubleView(double*, int dim, const int* sz);
+nb::object createNumPyDoubleView(double*, int dim, const int* sz);
 
 
 /// template function for converting iterables to numpy array of doubles
 template <class Iter>
-::boost::python::object
+nb::object
 convertToNumPyArray(Iter first, Iter last)
 {
     int sz = last - first;
@@ -268,7 +261,7 @@ convertToNumPyArray(Iter first, Iter last)
 
 
 /// specialization for R3::Vector
-inline ::boost::python::object
+inline nb::object
 convertToNumPyArray(const ::diffpy::srreal::R3::Vector& value)
 {
     return convertToNumPyArray(value.begin(), value.end());
@@ -276,7 +269,7 @@ convertToNumPyArray(const ::diffpy::srreal::R3::Vector& value)
 
 
 /// specialization for R3::Matrix
-inline ::boost::python::object
+inline nb::object
 convertToNumPyArray(const ::diffpy::srreal::R3::Matrix& mx)
 {
     using namespace diffpy::srreal;
@@ -291,7 +284,7 @@ convertToNumPyArray(const ::diffpy::srreal::R3::Matrix& mx)
 
 
 /// specialization for std::vector<R3::Vector>
-inline ::boost::python::object
+inline nb::object
 convertToNumPyArray(const ::std::vector<diffpy::srreal::R3::Vector>& vr3v)
 {
     using namespace diffpy::srreal;
@@ -312,7 +305,7 @@ convertToNumPyArray(const ::std::vector<diffpy::srreal::R3::Vector>& vr3v)
 
 
 /// specialization for QuantityType
-inline ::boost::python::object
+inline nb::object
 convertToNumPyArray(const ::diffpy::srreal::QuantityType& value)
 {
     return convertToNumPyArray(value.begin(), value.end());
@@ -320,27 +313,27 @@ convertToNumPyArray(const ::diffpy::srreal::QuantityType& value)
 
 
 /// NumPy array view specializations for R3::Vector
-boost::python::object
+nb::object
 viewAsNumPyArray(::diffpy::srreal::R3::Vector&);
 
 
 /// NumPy array view specializations for R3::Matrix
-boost::python::object
+nb::object
 viewAsNumPyArray(::diffpy::srreal::R3::Matrix&);
 
 
 /// Copy possible NumPy array to R3::Vector
 void assignR3Vector(
-        ::diffpy::srreal::R3::Vector& dst, boost::python::object& value);
+        ::diffpy::srreal::R3::Vector& dst, nb::object& value);
 
 
 /// Copy possible NumPy array to R3::Matrix
 void assignR3Matrix(
-        ::diffpy::srreal::R3::Matrix& dst, boost::python::object& value);
+        ::diffpy::srreal::R3::Matrix& dst, nb::object& value);
 
 
 /// Type for numpy array object and a raw pointer to its double data
-typedef std::pair<boost::python::object, int*> NumPyArray_IntPtr;
+typedef std::pair<nb::object, int*> NumPyArray_IntPtr;
 
 
 /// helper for creating numpy array of integers
@@ -348,7 +341,7 @@ NumPyArray_IntPtr createNumPyIntArray(int dim, const int* sz);
 
 
 /// specialization for a vector of integers
-inline ::boost::python::object
+inline nb::object
 convertToNumPyArray(const ::std::vector<int>& value)
 {
     int sz = value.size();
@@ -360,25 +353,24 @@ convertToNumPyArray(const ::std::vector<int>& value)
 
 /// template function for converting C++ STL container to a python list
 template <class T>
-::boost::python::list
+nb::list
 convertToPythonList(const T& value)
 {
-    using namespace ::boost;
-    python::list rvlist;
-    typename T::const_iterator ii;
-    for (ii = value.begin(); ii != value.end(); ++ii)  rvlist.append(*ii);
-    return rvlist;
+    nb::list rv;
+    for (auto const& item : value)
+        rv.append(item);
+    return rv;
 }
 
 
 /// template converter of a C++ map-like container to a python dictionary
 template <class T>
-::boost::python::dict
+nb::dict
 convertToPythonDict(const T& value)
 {
-    ::boost::python::dict rv;
-    typename T::const_iterator ii = value.begin();
-    for (; ii != value.end(); ++ii)  rv[ii->first] = ii->second;
+    nb::dict rv;
+    for (auto const& item : value)
+        rv[item.first] = item.second;
     return rv;
 }
 
@@ -387,48 +379,28 @@ convertToPythonDict(const T& value)
 /// If obj wraps a QuantityType reference, return that reference.
 /// Otherwise copy the obj values to rv and return rv.
 ::diffpy::srreal::QuantityType&
-extractQuantityType(::boost::python::object obj,
+extractQuantityType(nb::object obj,
         ::diffpy::srreal::QuantityType& rv);
 
 
 /// efficient conversion of Python object to a numpy array of doubles
-NumPyArray_DoublePtr extractNumPyDoubleArray(::boost::python::object& obj);
+NumPyArray_DoublePtr extractNumPyDoubleArray(nb::object& obj);
 
 
 /// extract double with a support for numpy numeric types
-double extractdouble(::boost::python::object obj);
+double extractdouble(nb::object obj);
 
 
 /// extract integer with a support for numpy.int types
-int extractint(::boost::python::object obj);
+int extractint(nb::object obj);
 
 
 /// extract a vector of integers from a numpy array, iterable or scalar
-std::vector<int> extractintvector(::boost::python::object obj);
+std::vector<int> extractintvector(nb::object obj);
 
 
 /// helper for raising RuntimeError on a call of pure virtual function
 void throwPureVirtualCalled(const char* fncname);
-
-
-/// template class for getting overrides to pure virtual method
-template <class T>
-class wrapper_srreal : public ::boost::python::wrapper<T>
-{
-    public:
-
-        typedef T base;
-
-    protected:
-
-        ::boost::python::override
-        get_pure_virtual_override(const char* name) const
-        {
-            ::boost::python::override f = this->get_override(name);
-            if (!f)  throwPureVirtualCalled(name);
-            return f;
-        }
-};
 
 }   // namespace srrealmodule
 

--- a/src/extensions/srreal_ext.cpp
+++ b/src/extensions/srreal_ext.cpp
@@ -16,39 +16,37 @@
 *
 *****************************************************************************/
 
-#include <boost/python/module.hpp>
-#include <boost/python/import.hpp>
-#include <boost/python/scope.hpp>
-#include <boost/python/extract.hpp>
-#include <boost/python/dict.hpp>
-#include "srreal_numpy_symbol.hpp"
+#include <nanobind/nanobind.h>
+
 #include <numpy/arrayobject.h>
 
 // Declaration of the external wrappers --------------------------------------
 
+namespace nb = nanobind;
+
 namespace srrealmodule {
 
-void wrap_libdiffpy_version();
+void wrap_libdiffpy_version(nb::module_& m);
 void wrap_exceptions();
-void wrap_EventTicker();
-void wrap_Attributes();
-void wrap_StructureDifference();
-void wrap_StructureAdapter();
-void wrap_AtomicStructureAdapter();
-void wrap_ObjCrystAdapters();
-void wrap_BaseBondGenerator();
-void wrap_PairQuantity();
-void wrap_PeakWidthModel();
-void wrap_ScatteringFactorTable();
-void wrap_PeakProfile();
-void wrap_BVParametersTable();
-void wrap_BVSCalculator();
-void wrap_PDFBaseline();
-void wrap_PDFEnvelope();
-void wrap_PDFCalculators();
-void wrap_BondCalculator();
-void wrap_AtomRadiiTable();
-void wrap_OverlapCalculator();
+void wrap_EventTicker(nb::module_& m);
+void wrap_Attributes(nb::module_& m);
+void wrap_StructureDifference(nb::module_& m);
+void wrap_StructureAdapter(nb::module_& m);
+void wrap_AtomicStructureAdapter(nb::module_& m);
+void wrap_ObjCrystAdapters(nb::module_& m);
+void wrap_BaseBondGenerator(nb::module_& m);
+void wrap_PairQuantity(nb::module_& m);
+void wrap_PeakWidthModel(nb::module_& m);
+void wrap_ScatteringFactorTable(nb::module_& m);
+void wrap_PeakProfile(nb::module_& m);
+void wrap_BVParametersTable(nb::module_& m);
+void wrap_BVSCalculator(nb::module_& m);
+void wrap_PDFBaseline(nb::module_& m);
+void wrap_PDFEnvelope(nb::module_& m);
+void wrap_PDFCalculators(nb::module_& m);
+void wrap_BondCalculator(nb::module_& m);
+void wrap_AtomRadiiTable(nb::module_& m);
+void wrap_OverlapCalculator(nb::module_& m);
 
 }   // namespace srrealmodule
 
@@ -64,46 +62,52 @@ namespace {
 
 // Module Definitions --------------------------------------------------------
 
-BOOST_PYTHON_MODULE(srreal_ext)
+NB_MODULE(srreal_ext, m)
 {
     using namespace srrealmodule;
     // initialize numpy module
     initialize_numpy();
     // execute external wrappers
-    wrap_libdiffpy_version();
+    wrap_libdiffpy_version(m);
     wrap_exceptions();
-    wrap_EventTicker();
-    wrap_Attributes();
-    wrap_StructureDifference();
-    wrap_StructureAdapter();
-    wrap_AtomicStructureAdapter();
-    wrap_ObjCrystAdapters();
-    wrap_BaseBondGenerator();
-    wrap_PairQuantity();
-    wrap_PeakWidthModel();
-    wrap_ScatteringFactorTable();
-    wrap_PeakProfile();
-    wrap_BVParametersTable();
-    wrap_BVSCalculator();
-    wrap_PDFBaseline();
-    wrap_PDFEnvelope();
-    wrap_PDFCalculators();
-    wrap_BondCalculator();
-    wrap_AtomRadiiTable();
-    wrap_OverlapCalculator();
+    wrap_EventTicker(m);
+    wrap_Attributes(m);
+    wrap_StructureDifference(m);
+    wrap_StructureAdapter(m);
+    wrap_AtomicStructureAdapter(m);
+    wrap_ObjCrystAdapters(m);
+    wrap_BaseBondGenerator(m);
+    wrap_PairQuantity(m);
+    wrap_PeakWidthModel(m);
+    wrap_ScatteringFactorTable(m);
+    wrap_PeakProfile(m);
+    wrap_BVParametersTable(m);
+    wrap_BVSCalculator(m);
+    wrap_PDFBaseline(m);
+    wrap_PDFEnvelope(m);
+    wrap_PDFCalculators(m);
+    wrap_BondCalculator(m);
+    wrap_AtomRadiiTable(m);
+    wrap_OverlapCalculator(m);
     // load Python modules that tweak the wrapped classes
-    using boost::python::object;
-    using boost::python::import;
-    using boost::python::scope;
-    using boost::python::extract;
-    using boost::python::dict;
-    object srreal = import("diffpy.srreal");
-    if (!PyObject_HasAttrString(srreal.ptr(), "_final_imports"))
+    nb::module_ srreal = nb::module_::import_("diffpy.srreal");
+    if (!nb::hasattr(srreal, "_final_imports"))
     {
-        dict sysmods = extract<dict>(import("sys").attr("modules"));
-        sysmods.setdefault("diffpy.srreal.srreal_ext", scope());
-        object import_now =
-            import("diffpy.srreal._final_imports").attr("import_now");
+        PyObject* sysmods = PyImport_GetModuleDict();
+
+        const char* fqname = "diffpy.srreal.srreal_ext";
+        if (PyDict_GetItemString(sysmods, fqname) == nullptr) 
+        {
+            if (PyDict_SetItemString(sysmods, fqname, m.ptr()) < 0) 
+            {
+                nb::raise_python_error();
+            }
+        }
+
+        nb::module_ final_imports =
+            nb::module_::import_("diffpy.srreal._final_imports");
+
+        nb::object import_now = final_imports.attr("import_now");
         import_now();
     }
 }

--- a/src/extensions/srreal_ext.cpp
+++ b/src/extensions/srreal_ext.cpp
@@ -18,6 +18,7 @@
 
 #include <nanobind/nanobind.h>
 
+#include "srreal_numpy_symbol.hpp"
 #include <numpy/arrayobject.h>
 
 // Declaration of the external wrappers --------------------------------------

--- a/src/extensions/srreal_ext.cpp
+++ b/src/extensions/srreal_ext.cpp
@@ -97,9 +97,9 @@ NB_MODULE(srreal_ext, m)
         PyObject* sysmods = PyImport_GetModuleDict();
 
         const char* fqname = "diffpy.srreal.srreal_ext";
-        if (PyDict_GetItemString(sysmods, fqname) == nullptr) 
+        if (PyDict_GetItemString(sysmods, fqname) == nullptr)
         {
-            if (PyDict_SetItemString(sysmods, fqname, m.ptr()) < 0) 
+            if (PyDict_SetItemString(sysmods, fqname, m.ptr()) < 0)
             {
                 nb::raise_python_error();
             }

--- a/src/extensions/srreal_pickling.cpp
+++ b/src/extensions/srreal_pickling.cpp
@@ -21,9 +21,7 @@
 #include <diffpy/srreal/StructureAdapter.hpp>
 
 namespace srrealmodule {
-namespace {
 
-using diffpy::srreal::StructureAdapterPtr;
 
 StructureAdapterPtr
 createStructureAdapterFromString(const std::string& content)
@@ -31,16 +29,6 @@ createStructureAdapterFromString(const std::string& content)
     StructureAdapterPtr adpt;
     diffpy::serialization_fromstring(adpt, content);
     return adpt;
-}
-
-}   // namespace
-
-// Non-member functions for StructureAdapterPickleSuite ----------------------
-
-boost::python::object
-StructureAdapter_constructor()
-{
-    return boost::python::make_constructor(createStructureAdapterFromString);
 }
 
 }   // namespace srrealmodule

--- a/src/extensions/srreal_pickling.cpp
+++ b/src/extensions/srreal_pickling.cpp
@@ -17,7 +17,6 @@
 *****************************************************************************/
 
 #include "srreal_pickling.hpp"
-#include <boost/python/make_constructor.hpp>
 #include <diffpy/srreal/StructureAdapter.hpp>
 
 namespace srrealmodule {

--- a/src/extensions/srreal_pickling.hpp
+++ b/src/extensions/srreal_pickling.hpp
@@ -20,6 +20,7 @@
 #define SRREAL_PICKLING_HPP_INCLUDED
 
 #include <nanobind/nanobind.h>
+#include <nanobind/stl/shared_ptr.h>
 
 #include <string>
 #include <sstream>

--- a/src/extensions/srreal_pickling.hpp
+++ b/src/extensions/srreal_pickling.hpp
@@ -23,6 +23,7 @@
 
 #include <string>
 #include <sstream>
+#include <type_traits>
 
 #include <diffpy/serialization.hpp>
 #include <diffpy/srreal/forwardtypes.hpp>
@@ -82,14 +83,24 @@ nb::object resolve_state_object(nb::object value)
 template <class T>
 void assign_state_object(T target, nb::object value)
 {
-    if (!value.is_none())  target = nb::cast<T>(value);
+    if (!value.is_none())  target = value;
 }
 
 
 template <class T>
 void construct_for_unpickle(T* tobj)
 {
-    new (tobj) T();
+    if constexpr (std::is_default_constructible_v<T> && !std::is_abstract_v<T>)
+    {
+        new (tobj) T();
+    }
+    else
+    {
+        throw nb::type_error(
+            "cannot unpickle an uninitialized non-default-constructible "
+            "C++ instance"
+        );
+    }
 }
 
 
@@ -127,7 +138,7 @@ class SerializationPickleSuite
         static nb::tuple getstate(nb::object obj)
         {
             const T& tobj = nb::cast<const T&>(obj);
-            nb::bytes content = serialization_tobytes(*tobj);
+            nb::bytes content = serialization_tobytes(tobj);
 
             if constexpr (pickledict) 
             {

--- a/src/extensions/srreal_pickling.hpp
+++ b/src/extensions/srreal_pickling.hpp
@@ -19,11 +19,7 @@
 #ifndef SRREAL_PICKLING_HPP_INCLUDED
 #define SRREAL_PICKLING_HPP_INCLUDED
 
-#include <boost/python/class.hpp>
-#include <boost/python/tuple.hpp>
-#include <boost/python/dict.hpp>
-#include <boost/python/str.hpp>
-#include <boost/python/operators.hpp>
+#include <nanobind/nanobind.h>
 
 #include <string>
 #include <sstream>
@@ -31,94 +27,135 @@
 #include <diffpy/serialization.hpp>
 #include <diffpy/srreal/forwardtypes.hpp>
 
+namespace nb = nanobind;
+
 namespace srrealmodule {
 
 inline
-void ensure_tuple_length(boost::python::tuple state, const int statelen)
+void ensure_tuple_length(nb::tuple state, const int statelen)
 {
-    using namespace boost::python;
-    if (len(state) == statelen)  return;
-    object emsg = ("expected %i-item tuple in call to "
-            "__setstate__; got %s" % make_tuple(statelen, state));
-    PyErr_SetObject(PyExc_ValueError, emsg.ptr());
-    throw_error_already_set();
+    if (state.size() == statelen)  return;
+    PyErr_Format(
+        PyExc_ValueError,
+        "expected %d-item tuple in call to __setstate__; got %zd",
+        statelen,
+        state.size()
+    );
+    nb::raise_python_error();
 }
 
 
 template <typename T>
-::boost::python::object serialization_tobytes(const T& tobj)
+nb::bytes serialization_tobytes(const T& tobj)
 {
     std::string s = diffpy::serialization_tostring(tobj);
-    std::string::const_pointer pfirst = s.empty() ? NULL : &(s[0]);
-    boost::python::object rv(
-            boost::python::handle<>(
-                PyBytes_FromStringAndSize(pfirst, s.size()))
-            );
-    return rv;
+    return nb::bytes(s.data(), s.size());
 }
 
-
-template <class T>
-bool is_wrapper(::boost::python::object& obj)
+template <typename H>
+std::string bytes_to_string(const H& h)
 {
-    T* p = ::boost::python::extract<T*>(obj);
-    typedef ::boost::python::wrapper<T> W;
-    bool rv = (dynamic_cast<W*>(p) != NULL);
-    return rv;
+    nb::bytes py_content(h);
+    return std::string(
+        static_cast<const char *>(py_content.data()),
+        py_content.size()
+    );
 }
 
 
 template <class T>
-::boost::python::object resolve_state_object(::boost::python::object value)
+bool is_wrapper(nb::object& obj)
+{
+    T* p = nullptr;
+    return nb::try_cast<T*>(obj, p, false) && p;
+}
+
+
+template <class T>
+nb::object resolve_state_object(nb::object value)
 {
     // return None if value holds a pristine C++ instance of T
-    ::boost::python::object rv;
-    if (is_wrapper<T>(value))  rv = value;
-    return rv;
+    return is_wrapper<T>(value) ? value : nb::none();
 }
 
 
 template <class T>
-void assign_state_object(T target, ::boost::python::object value)
+void assign_state_object(T target, nb::object value)
 {
-    if (!value.is_none())  target = value;
+    if (!value.is_none())  target = nb::cast<T>(value);
+}
+
+
+template <class T>
+void construct_for_unpickle(T* tobj)
+{
+    new (tobj) T();
+}
+
+
+template <class T>
+T& ensure_instance_ready(nb::handle obj)
+{
+    T* tobj = nb::inst_ptr<T>(obj);
+
+    if (!nb::inst_ready(obj)) 
+    {
+        construct_for_unpickle(tobj);
+        nb::inst_mark_ready(obj);
+    }
+
+    return *tobj;
 }
 
 
 enum {DICT_IGNORE=false, DICT_PICKLE=true};
 
 template <class T, bool pickledict=DICT_IGNORE>
-class SerializationPickleSuite : public boost::python::pickle_suite
+class SerializationPickleSuite
 {
     public:
 
-        static boost::python::tuple getstate(boost::python::object obj)
+        template <typename C>
+        static void bind(C& cls)
         {
-            using namespace std;
-            const T& tobj = boost::python::extract<const T&>(obj);
-            boost::python::object content = serialization_tobytes(tobj);
-            boost::python::tuple rv = pickledict ?
-                boost::python::make_tuple(content, obj.attr("__dict__")) :
-                boost::python::make_tuple(content);
-            return rv;
+            cls
+                .def("__getstate__", getstate)
+                .def("__setstate__", setstate)
+                ;
+        }
+
+        static nb::tuple getstate(nb::object obj)
+        {
+            const T& tobj = nb::cast<const T&>(obj);
+            nb::bytes content = serialization_tobytes(*tobj);
+
+            if constexpr (pickledict) 
+            {
+                return nb::make_tuple(
+                    content,
+                    nb::getattr(obj, "__dict__")
+                );
+            } 
+            else 
+            {
+                return nb::make_tuple(content);
+            }
         }
 
 
         static void setstate(
-                boost::python::object obj, boost::python::tuple state)
+                nb::object obj, nb::tuple state)
         {
-            using namespace std;
-            using namespace boost::python;
-            T& tobj = extract<T&>(obj);
-            int statelen = pickledict ? 2 : 1;
+            constexpr int statelen = pickledict ? 2 : 1;
             ensure_tuple_length(state, statelen);
             // load the C++ object
-            string content = extract<string>(state[0]);
-            diffpy::serialization_fromstring(tobj, content);
+            T& tobj = ensure_instance_ready<T>(obj);
+            diffpy::serialization_fromstring(tobj, bytes_to_string(state[0]));
             // restore the object's __dict__
-            if (pickledict)
+            if constexpr (pickledict)
             {
-                dict d = extract<dict>(obj.attr("__dict__"));
+                nb::object dict_obj = nb::getattr(obj, "__dict__");
+                nb::dict d = nb::borrow<nb::dict>(dict_obj);
                 d.update(state[1]);
             }
         }
@@ -138,36 +175,42 @@ class PairQuantityPickleSuite :
 
     public:
 
-        static boost::python::tuple getstate(boost::python::object obj)
+        template <typename C>
+        static void bind(C& cls)
         {
-            using namespace boost::python;
+            cls
+                .def("__getstate__", getstate)
+                .def("__setstate__", setstate)
+                ;
+        }
+
+        static nb::tuple getstate(nb::object obj)
+        {
             using namespace diffpy::srreal;
             // store the original structure object
-            object stru = obj.attr("getStructure")();
+            nb::object stru = obj.attr("getStructure")();
             // temporarily remove structure from the pair quantity
-            T& pq = extract<T&>(obj);
+            T& pq = ensure_instance_ready<T>(obj);
             StructureAdapterPtr pstru =
                 replacePairQuantityStructure(pq, StructureAdapterPtr());
-            object state0 = Super::getstate(obj);
+            nb::object state0 = Super::getstate(obj);
             // restore the original structure
             replacePairQuantityStructure(pq, pstru);
-            tuple rv = make_tuple(state0, stru);
-            return rv;
+            return nb::make_tuple(state0, stru);
         }
 
 
         static void setstate(
-                boost::python::object obj, boost::python::tuple state)
+                nb::object obj, nb::tuple state)
         {
-            using namespace boost::python;
             using namespace diffpy::srreal;
             ensure_tuple_length(state, 2);
             // restore the state using boost serialization
-            tuple st0 = extract<tuple>(state[0]);
-            Super::setstate(obj, st0);
+            nb::tuple state0(state[0]);
+            Super::setstate(obj, state0);
             // restore the structure object
-            StructureAdapterPtr pstru = extract<StructureAdapterPtr>(state[1]);
-            T& pq = extract<T&>(obj);
+            StructureAdapterPtr pstru = nb::cast<StructureAdapterPtr>(state[1]);
+            T& pq = ensure_instance_ready<T>(obj);
             replacePairQuantityStructure(pq, pstru);
         }
 
@@ -175,64 +218,44 @@ class PairQuantityPickleSuite :
 
 
 template <class T>
-class StructureAdapterPickleSuite : public boost::python::pickle_suite
+class StructureAdapterPickleSuite
 {
     public:
 
-        static boost::python::tuple getinitargs(
-                diffpy::srreal::StructureAdapterPtr adpt)
+        template <typename C>
+        static void bind(C& cls)
         {
-            using namespace boost;
-            python::tuple rv;
-            // if adapter has been created from Python, we can use the default
-            // Python constructor, i.e., __init__ with no arguments.
-            if (frompython(adpt))  return rv;
-            // otherwise the instance is from a non-wrapped C++ adapter,
-            // and we need to reconstruct it using boost::serialization
-            python::object content = serialization_tobytes(adpt);
-            rv = python::make_tuple(content);
-            return rv;
+            cls
+                .def("__getstate__", getstate)
+                .def("__setstate__", setstate)
+                ;
         }
 
 
-        static boost::python::tuple getstate(boost::python::object obj)
+        static nb::tuple getstate(nb::object obj)
         {
-            using namespace boost;
-            using namespace std;
-            using diffpy::srreal::StructureAdapterPtr;
-            StructureAdapterPtr adpt =
-                python::extract<StructureAdapterPtr>(obj);
-            python::object content;
-            // Store serialization data for a Python-built object
-            if (frompython(adpt))
-            {
-                const T& tobj = boost::python::extract<const T&>(obj);
-                content = serialization_tobytes(tobj);
-            }
-            python::tuple rv =
-                python::make_tuple(content, obj.attr("__dict__"));
-            return rv;
+            const T& tobj = nb::cast<const T&>(obj);
+            nb::bytes content = serialization_tobytes(tobj);
+            return nb::make_tuple(content, nb::getattr(obj, "__dict__"));
         }
 
 
         static void setstate(
-                boost::python::object obj, boost::python::tuple state)
+                nb::object obj, nb::tuple state)
         {
-            using namespace std;
-            using namespace boost::python;
             ensure_tuple_length(state, 2);
             // Restore the C++ data from state[0] for Python built-objects.
             // state[0] is None for C++ objects and there is no need to do
             // anything as those were already restored by string constructor.
-            object st0 = state[0];
+            nb::object st0 = nb::borrow<nb::object>(state[0]);
             if (!st0.is_none())
             {
-                T& tobj = extract<T&>(obj);
-                string content = extract<string>(st0);
-                diffpy::serialization_fromstring(tobj, content);
+                T& tobj = ensure_instance_ready<T>(obj);
+                diffpy::serialization_fromstring(tobj, bytes_to_string(st0));
             }
             // restore the object's __dict__
-            dict d = extract<dict>(obj.attr("__dict__"));
+            nb::object dict_obj = nb::getattr(obj, "__dict__");
+            nb::dict d = nb::borrow<nb::dict>(dict_obj);
             d.update(state[1]);
         }
 
@@ -252,7 +275,34 @@ class StructureAdapterPickleSuite : public boost::python::pickle_suite
 
 /// Helper function for creating Python constructor from string
 /// that restores c++ non-wrapped classes.
-boost::python::object StructureAdapter_constructor();
+using diffpy::srreal::StructureAdapterPtr;
+
+StructureAdapterPtr
+createStructureAdapterFromString(const std::string &content);
+
+template <class Adapter>
+std::shared_ptr<Adapter>
+createAdapterFromString(const std::string &content) 
+{
+    StructureAdapterPtr base = createStructureAdapterFromString(content);
+
+    auto rv = std::dynamic_pointer_cast<Adapter>(base);
+    if (!rv) 
+    {
+        throw nb::type_error(
+            "serialized content does not contain the requested adapter type"
+        );
+    }
+
+    return rv;
+}
+
+template <class Adapter>
+void StructureAdapter_constructor(Adapter* self, const std::string& content) 
+{
+    std::shared_ptr<Adapter> adpt = createAdapterFromString<Adapter>(content);
+    new (self) Adapter(*adpt);
+}
 
 }   // namespace srrealmodule
 

--- a/src/extensions/srreal_pickling.hpp
+++ b/src/extensions/srreal_pickling.hpp
@@ -245,7 +245,7 @@ class StructureAdapterPickleSuite : public boost::python::pickle_suite
         static bool frompython(
                 diffpy::srreal::StructureAdapterPtr adpt)
         {
-            return bool(boost::dynamic_pointer_cast<T>(adpt));
+            return bool(std::dynamic_pointer_cast<T>(adpt));
         }
 
 };  // class StructureAdapterPickleSuite

--- a/src/extensions/srreal_pickling.hpp
+++ b/src/extensions/srreal_pickling.hpp
@@ -276,9 +276,14 @@ class ScopedSharedPtrReplacement
 };
 
 
-enum {DICT_IGNORE=false, DICT_PICKLE=true};
+enum PickleDictPolicy
+{
+    DICT_GUARD,
+    DICT_PICKLE,
+    DICT_DISCARD
+};
 
-template <class T, bool pickledict=DICT_IGNORE, class Storage=T>
+template <class T, PickleDictPolicy dictpolicy=DICT_GUARD, class Storage=T>
 class SerializationPickleSuite
 {
     public:
@@ -291,7 +296,7 @@ class SerializationPickleSuite
                 .def("__setstate__", setstate)
                 .def("__reduce__", reduce)
                 ;
-            if constexpr (pickledict)
+            if constexpr (dictpolicy == DICT_PICKLE)
             {
                 cls.attr("__getstate_manages_dict__") = nb::bool_(true);
             }
@@ -306,14 +311,16 @@ class SerializationPickleSuite
             const T& tobj = nb::cast<const T&>(obj);
             nb::bytes content = serialization_tobytes(tobj);
 
-            bool manages_dict = state_manages_dict(obj, pickledict);
-            ensure_dict_is_managed_or_empty(obj, manages_dict);
-            if (manages_dict)
+            if constexpr (dictpolicy == DICT_PICKLE)
             {
                 return nb::make_tuple(
                     content,
                     get_instance_dict(obj)
                 );
+            }
+            if constexpr (dictpolicy == DICT_GUARD)
+            {
+                ensure_dict_is_managed_or_empty(obj, false);
             }
             return nb::make_tuple(content);
         }
@@ -322,15 +329,15 @@ class SerializationPickleSuite
         static void setstate(
                 nb::object obj, nb::tuple state)
         {
-            bool manages_dict = state_manages_dict(obj, pickledict);
-            ensure_tuple_length(state, manages_dict ? 2 : 1);
+            ensure_tuple_length(
+                state,
+                dictpolicy == DICT_PICKLE ? 2 : 1);
             // load the C++ object
             T& tobj = nb::cast<T&>(obj);
             diffpy::serialization_fromstring(tobj, bytes_to_string(state[0]));
             // restore the object's __dict__
-            if (manages_dict)
+            if constexpr (dictpolicy == DICT_PICKLE)
             {
-                ensure_dict_is_managed_or_empty(obj, manages_dict);
                 restore_instance_dict(obj, state[1]);
             }
         }
@@ -344,18 +351,21 @@ class SerializationPickleSuite
             );
         }
 
-        static bool getstate_manages_dict()  { return pickledict; }
+        static bool getstate_manages_dict()
+        {
+            return dictpolicy == DICT_PICKLE;
+        }
 
 };  // class SerializationPickleSuite
 
 
-template <class T, bool pickledict=DICT_IGNORE, class Storage=T>
+template <class T, PickleDictPolicy dictpolicy=DICT_GUARD, class Storage=T>
 class PairQuantityPickleSuite :
-    public SerializationPickleSuite<T, pickledict, Storage>
+    public SerializationPickleSuite<T, dictpolicy, Storage>
 {
     private:
 
-        typedef SerializationPickleSuite<T, pickledict, Storage> Super;
+        typedef SerializationPickleSuite<T, dictpolicy, Storage> Super;
 
     public:
 
@@ -367,7 +377,7 @@ class PairQuantityPickleSuite :
                 .def("__setstate__", setstate)
                 .def("__reduce__", reduce)
                 ;
-            if constexpr (pickledict)
+            if constexpr (dictpolicy == DICT_PICKLE)
             {
                 cls.attr("__getstate_manages_dict__") = nb::bool_(true);
             }

--- a/src/extensions/srreal_pickling.hpp
+++ b/src/extensions/srreal_pickling.hpp
@@ -21,10 +21,13 @@
 
 #include <nanobind/nanobind.h>
 #include <nanobind/stl/shared_ptr.h>
+#include <nanobind/stl/string.h>
 
 #include <string>
 #include <sstream>
-#include <type_traits>
+#include <stdexcept>
+#include <utility>
+#include <memory>
 
 #include <diffpy/serialization.hpp>
 #include <diffpy/srreal/forwardtypes.hpp>
@@ -33,10 +36,16 @@ namespace nb = nanobind;
 
 namespace srrealmodule {
 
+struct PythonTrampolineTag
+{
+    virtual ~PythonTrampolineTag() = default;
+};
+
+
 inline
 void ensure_tuple_length(nb::tuple state, const int statelen)
 {
-    if (state.size() == statelen)  return;
+    if (state.size() == static_cast<size_t>(statelen))  return;
     PyErr_Format(
         PyExc_ValueError,
         "expected %d-item tuple in call to __setstate__; got %zd",
@@ -54,75 +63,222 @@ nb::bytes serialization_tobytes(const T& tobj)
     return nb::bytes(s.data(), s.size());
 }
 
-template <typename H>
-std::string bytes_to_string(const H& h)
+inline
+std::string bytes_to_string(nb::handle h)
 {
-    nb::bytes py_content(h);
+    if (!PyBytes_Check(h.ptr()))
+    {
+        PyErr_SetString(PyExc_TypeError, "expected bytes");
+        nb::raise_python_error();
+    }
+    char *buffer = nullptr;
+    Py_ssize_t size = 0;
+    if (PyBytes_AsStringAndSize(h.ptr(), &buffer, &size) < 0)
+        nb::raise_python_error();
     return std::string(
-        static_cast<const char *>(py_content.data()),
-        py_content.size()
+        static_cast<const char *>(buffer),
+        static_cast<size_t>(size)
     );
 }
 
 
-template <class T>
-bool is_wrapper(nb::object& obj)
+inline
+nb::object runtime_type(nb::handle obj)
 {
-    T* p = nullptr;
-    return nb::try_cast<T*>(obj, p, false) && p;
+    return nb::borrow<nb::object>(reinterpret_cast<PyObject *>(Py_TYPE(obj.ptr())));
 }
 
 
-template <class T>
-nb::object resolve_state_object(nb::object value)
+inline
+nb::object get_instance_dict(nb::handle obj)
 {
-    // return None if value holds a pristine C++ instance of T
-    return is_wrapper<T>(value) ? value : nb::none();
-}
-
-
-template <class T>
-void assign_state_object(T target, nb::object value)
-{
-    if (!value.is_none())  target = value;
-}
-
-
-template <class T>
-void construct_for_unpickle(T* tobj)
-{
-    if constexpr (std::is_default_constructible_v<T> && !std::is_abstract_v<T>)
+    PyObject *dict = PyObject_GetAttrString(obj.ptr(), "__dict__");
+    if (!dict)
     {
-        new (tobj) T();
+        if (PyErr_ExceptionMatches(PyExc_AttributeError))
+        {
+            PyErr_Clear();
+            return nb::none();
+        }
+        nb::raise_python_error();
     }
-    else
+    return nb::steal<nb::object>(dict);
+}
+
+
+inline
+bool state_manages_dict(nb::handle obj, bool default_policy)
+{
+    PyObject *flag =
+        PyObject_GetAttrString(reinterpret_cast<PyObject *>(Py_TYPE(obj.ptr())),
+                               "__getstate_manages_dict__");
+    if (!flag)
     {
-        throw nb::type_error(
-            "cannot unpickle an uninitialized non-default-constructible "
-            "C++ instance"
-        );
+        if (PyErr_ExceptionMatches(PyExc_AttributeError))
+        {
+            PyErr_Clear();
+            return default_policy;
+        }
+        nb::raise_python_error();
     }
+    nb::object flag_obj = nb::steal<nb::object>(flag);
+    if (flag_obj.is_none())  return false;
+    int rv = PyObject_IsTrue(flag_obj.ptr());
+    if (rv < 0)  nb::raise_python_error();
+    return rv != 0;
+}
+
+
+inline
+void ensure_dict_is_managed_or_empty(nb::handle obj, bool manages_dict)
+{
+    if (manages_dict)  return;
+    nb::object dict_obj = get_instance_dict(obj);
+    if (dict_obj.is_none())  return;
+    Py_ssize_t n = PyMapping_Size(dict_obj.ptr());
+    if (n < 0)  nb::raise_python_error();
+    if (n == 0)  return;
+    throw std::runtime_error(
+        "Incomplete pickle support (__getstate_manages_dict__ not set)"
+    );
+}
+
+
+inline
+void ensure_mapping_state(nb::handle state)
+{
+    if (!PyMapping_Check(state.ptr()))
+    {
+        PyErr_SetString(PyExc_TypeError, "pickle __dict__ state must be a mapping");
+        nb::raise_python_error();
+    }
+
+    PyObject *keys = PyMapping_Keys(state.ptr());
+    if (!keys)
+    {
+        if (PyErr_ExceptionMatches(PyExc_AttributeError))
+        {
+            PyErr_Clear();
+            PyErr_SetString(
+                PyExc_TypeError,
+                "pickle __dict__ state must be a mapping"
+            );
+        }
+        nb::raise_python_error();
+    }
+    Py_DECREF(keys);
+}
+
+
+inline
+void restore_instance_dict(nb::handle obj, nb::handle dict_state)
+{
+    if (dict_state.is_none())  return;
+    ensure_mapping_state(dict_state);
+
+    nb::object dict_obj = get_instance_dict(obj);
+    if (dict_obj.is_none())
+    {
+        Py_ssize_t n = PyMapping_Size(dict_state.ptr());
+        if (n < 0)  nb::raise_python_error();
+        if (n == 0)  return;
+        PyErr_SetString(PyExc_TypeError, "object has no __dict__ to restore");
+        nb::raise_python_error();
+    }
+    if (!PyDict_Check(dict_obj.ptr()))
+    {
+        PyErr_SetString(PyExc_TypeError, "object __dict__ is not a dict");
+        nb::raise_python_error();
+    }
+    if (PyDict_Update(dict_obj.ptr(), dict_state.ptr()) < 0)
+        nb::raise_python_error();
 }
 
 
 template <class T>
-T& ensure_instance_ready(nb::handle obj)
+bool is_python_trampoline(T *ptr)
 {
-    T* tobj = nb::inst_ptr<T>(obj);
-
-    if (!nb::inst_ready(obj)) 
-    {
-        construct_for_unpickle(tobj);
-        nb::inst_mark_ready(obj);
-    }
-
-    return *tobj;
+    return dynamic_cast<PythonTrampolineTag *>(ptr) != nullptr;
 }
+
+
+template <class T>
+bool is_python_trampoline(nb::handle obj)
+{
+    T *ptr = nullptr;
+    return nb::try_cast<T *>(obj, ptr, false) &&
+        ptr && is_python_trampoline(ptr);
+}
+
+
+template <class T>
+void assign_pointer_state(std::shared_ptr<T>& slot, nb::handle value)
+{
+    nb::object value_obj = nb::borrow<nb::object>(value);
+    if (value_obj.is_none())  return;
+    slot = nb::cast<std::shared_ptr<T>>(value_obj);
+}
+
+
+template <class T>
+nb::object resolve_state_pointer(const std::shared_ptr<T>& value)
+{
+    // Return None for native extension objects. Python-defined wrappers are
+    // pickled independently so their dictionaries and virtual overrides survive.
+    if (!value || !std::dynamic_pointer_cast<PythonTrampolineTag>(value))
+        return nb::none();
+    return nb::cast(value);
+}
+
+
+template <class T>
+class ScopedSharedPtrReplacement
+{
+    public:
+
+        ScopedSharedPtrReplacement(
+                std::shared_ptr<T>& slot,
+                std::shared_ptr<T> replacement) :
+            mslot(slot),
+            moriginal(slot),
+            mstate(resolve_state_pointer<T>(moriginal)),
+            mreplacement(std::move(replacement))
+        {
+            if (mstate.is_none())  return;
+            mslot = mreplacement;
+            mactive = true;
+        }
+
+        ~ScopedSharedPtrReplacement()
+        {
+            restore();
+        }
+
+        nb::object state_object() const
+        {
+            return mstate;
+        }
+
+        void restore() noexcept
+        {
+            if (!mactive)  return;
+            mslot = moriginal;
+            mactive = false;
+        }
+
+    private:
+
+        std::shared_ptr<T>& mslot;
+        std::shared_ptr<T> moriginal;
+        nb::object mstate;
+        std::shared_ptr<T> mreplacement;
+        bool mactive = false;
+};
 
 
 enum {DICT_IGNORE=false, DICT_PICKLE=true};
 
-template <class T, bool pickledict=DICT_IGNORE>
+template <class T, bool pickledict=DICT_IGNORE, class Storage=T>
 class SerializationPickleSuite
 {
     public:
@@ -133,7 +289,16 @@ class SerializationPickleSuite
             cls
                 .def("__getstate__", getstate)
                 .def("__setstate__", setstate)
+                .def("__reduce__", reduce)
                 ;
+            if constexpr (pickledict)
+            {
+                cls.attr("__getstate_manages_dict__") = nb::bool_(true);
+            }
+            else
+            {
+                cls.attr("__getstate_manages_dict__") = nb::none();
+            }
         }
 
         static nb::tuple getstate(nb::object obj)
@@ -141,35 +306,42 @@ class SerializationPickleSuite
             const T& tobj = nb::cast<const T&>(obj);
             nb::bytes content = serialization_tobytes(tobj);
 
-            if constexpr (pickledict) 
+            bool manages_dict = state_manages_dict(obj, pickledict);
+            ensure_dict_is_managed_or_empty(obj, manages_dict);
+            if (manages_dict)
             {
                 return nb::make_tuple(
                     content,
-                    nb::getattr(obj, "__dict__")
+                    get_instance_dict(obj)
                 );
-            } 
-            else 
-            {
-                return nb::make_tuple(content);
             }
+            return nb::make_tuple(content);
         }
 
 
         static void setstate(
                 nb::object obj, nb::tuple state)
         {
-            constexpr int statelen = pickledict ? 2 : 1;
-            ensure_tuple_length(state, statelen);
+            bool manages_dict = state_manages_dict(obj, pickledict);
+            ensure_tuple_length(state, manages_dict ? 2 : 1);
             // load the C++ object
-            T& tobj = ensure_instance_ready<T>(obj);
+            T& tobj = nb::cast<T&>(obj);
             diffpy::serialization_fromstring(tobj, bytes_to_string(state[0]));
             // restore the object's __dict__
-            if constexpr (pickledict)
+            if (manages_dict)
             {
-                nb::object dict_obj = nb::getattr(obj, "__dict__");
-                nb::dict d = nb::borrow<nb::dict>(dict_obj);
-                d.update(state[1]);
+                ensure_dict_is_managed_or_empty(obj, manages_dict);
+                restore_instance_dict(obj, state[1]);
             }
+        }
+
+        static nb::tuple reduce(nb::object obj)
+        {
+            return nb::make_tuple(
+                runtime_type(obj),
+                nb::make_tuple(),
+                obj.attr("__getstate__")()
+            );
         }
 
         static bool getstate_manages_dict()  { return pickledict; }
@@ -177,13 +349,13 @@ class SerializationPickleSuite
 };  // class SerializationPickleSuite
 
 
-template <class T, bool pickledict=DICT_IGNORE>
+template <class T, bool pickledict=DICT_IGNORE, class Storage=T>
 class PairQuantityPickleSuite :
-    public SerializationPickleSuite<T, pickledict>
+    public SerializationPickleSuite<T, pickledict, Storage>
 {
     private:
 
-        typedef SerializationPickleSuite<T, pickledict> Super;
+        typedef SerializationPickleSuite<T, pickledict, Storage> Super;
 
     public:
 
@@ -193,21 +365,57 @@ class PairQuantityPickleSuite :
             cls
                 .def("__getstate__", getstate)
                 .def("__setstate__", setstate)
+                .def("__reduce__", reduce)
                 ;
+            if constexpr (pickledict)
+            {
+                cls.attr("__getstate_manages_dict__") = nb::bool_(true);
+            }
+            else
+            {
+                cls.attr("__getstate_manages_dict__") = nb::none();
+            }
         }
 
         static nb::tuple getstate(nb::object obj)
         {
             using namespace diffpy::srreal;
-            // store the original structure object
-            nb::object stru = obj.attr("getStructure")();
+            T& pq = nb::cast<T&>(obj);
             // temporarily remove structure from the pair quantity
-            T& pq = ensure_instance_ready<T>(obj);
-            StructureAdapterPtr pstru =
-                replacePairQuantityStructure(pq, StructureAdapterPtr());
-            nb::object state0 = Super::getstate(obj);
-            // restore the original structure
-            replacePairQuantityStructure(pq, pstru);
+            StructureAdapterPtr& structure_slot = pq.getStructure();
+            StructureAdapterPtr pstru = structure_slot;
+            nb::object stru = pstru ? nb::cast(pstru) : nb::none();
+            structure_slot.reset();
+            struct RestoreStructure
+            {
+                StructureAdapterPtr& slot;
+                StructureAdapterPtr pstru;
+                bool active = true;
+
+                ~RestoreStructure()
+                {
+                    restore();
+                }
+
+                void restore() noexcept
+                {
+                    if (!active)  return;
+                    slot = pstru;
+                    active = false;
+                }
+            } restore{structure_slot, pstru};
+
+            nb::object state0;
+            try
+            {
+                state0 = Super::getstate(obj);
+            }
+            catch (...)
+            {
+                restore.restore();
+                throw;
+            }
+            restore.restore();
             return nb::make_tuple(state0, stru);
         }
 
@@ -222,14 +430,19 @@ class PairQuantityPickleSuite :
             Super::setstate(obj, state0);
             // restore the structure object
             StructureAdapterPtr pstru = nb::cast<StructureAdapterPtr>(state[1]);
-            T& pq = ensure_instance_ready<T>(obj);
-            replacePairQuantityStructure(pq, pstru);
+            T& pq = nb::cast<T&>(obj);
+            pq.getStructure() = pstru;
+        }
+
+        static nb::tuple reduce(nb::object obj)
+        {
+            return Super::reduce(obj);
         }
 
 };  // class PairQuantityPickleSuite
 
 
-template <class T>
+template <class T, class Storage=T>
 class StructureAdapterPickleSuite
 {
     public:
@@ -240,15 +453,23 @@ class StructureAdapterPickleSuite
             cls
                 .def("__getstate__", getstate)
                 .def("__setstate__", setstate)
+                .def("__reduce__", reduce)
                 ;
+            cls.attr("__getstate_manages_dict__") = nb::bool_(true);
         }
 
 
         static nb::tuple getstate(nb::object obj)
         {
-            const T& tobj = nb::cast<const T&>(obj);
-            nb::bytes content = serialization_tobytes(tobj);
-            return nb::make_tuple(content, nb::getattr(obj, "__dict__"));
+            diffpy::srreal::StructureAdapterPtr adpt =
+                nb::cast<diffpy::srreal::StructureAdapterPtr>(obj);
+            nb::object content = nb::none();
+            if (frompython(adpt))
+            {
+                const T& tobj = nb::cast<const T&>(obj);
+                content = serialization_tobytes(tobj);
+            }
+            return nb::make_tuple(content, get_instance_dict(obj));
         }
 
 
@@ -262,15 +483,35 @@ class StructureAdapterPickleSuite
             nb::object st0 = nb::borrow<nb::object>(state[0]);
             if (!st0.is_none())
             {
-                T& tobj = ensure_instance_ready<T>(obj);
+                T& tobj = nb::cast<T&>(obj);
                 diffpy::serialization_fromstring(tobj, bytes_to_string(st0));
             }
             // restore the object's __dict__
-            nb::object dict_obj = nb::getattr(obj, "__dict__");
-            nb::dict d = nb::borrow<nb::dict>(dict_obj);
-            d.update(state[1]);
+            restore_instance_dict(obj, state[1]);
         }
 
+        static nb::tuple reduce(nb::object obj)
+        {
+            diffpy::srreal::StructureAdapterPtr adpt =
+                nb::cast<diffpy::srreal::StructureAdapterPtr>(obj);
+            if (frompython(adpt))
+            {
+                return nb::make_tuple(
+                    runtime_type(obj),
+                    nb::make_tuple(),
+                    obj.attr("__getstate__")()
+                );
+            }
+
+            nb::object restore = nb::module_::import_(
+                "diffpy.srreal.srreal_ext").attr("_restoreStructureAdapter");
+            nb::bytes content = serialization_tobytes(adpt);
+            return nb::make_tuple(
+                restore,
+                nb::make_tuple(content),
+                nb::make_tuple(nb::none(), get_instance_dict(obj))
+            );
+        }
 
         static bool getstate_manages_dict()  { return true; }
 
@@ -280,7 +521,7 @@ class StructureAdapterPickleSuite
         static bool frompython(
                 diffpy::srreal::StructureAdapterPtr adpt)
         {
-            return bool(std::dynamic_pointer_cast<T>(adpt));
+            return bool(std::dynamic_pointer_cast<PythonTrampolineTag>(adpt));
         }
 
 };  // class StructureAdapterPickleSuite
@@ -310,10 +551,19 @@ createAdapterFromString(const std::string &content)
 }
 
 template <class Adapter>
-void StructureAdapter_constructor(Adapter* self, const std::string& content) 
+void StructureAdapter_constructor(
+        nb::pointer_and_handle<Adapter> self, nb::bytes content)
 {
-    std::shared_ptr<Adapter> adpt = createAdapterFromString<Adapter>(content);
-    new (self) Adapter(*adpt);
+    if (!runtime_type(self.h).is(nb::type<Adapter>()))
+    {
+        throw nb::type_error(
+            "serialized StructureAdapter constructor is only supported "
+            "for native extension types"
+        );
+    }
+    std::shared_ptr<Adapter> adpt =
+        createAdapterFromString<Adapter>(bytes_to_string(content));
+    new (self.p) Adapter(*adpt);
 }
 
 }   // namespace srrealmodule

--- a/src/extensions/srreal_pickling.hpp
+++ b/src/extensions/srreal_pickling.hpp
@@ -545,12 +545,12 @@ createStructureAdapterFromString(const std::string &content);
 
 template <class Adapter>
 std::shared_ptr<Adapter>
-createAdapterFromString(const std::string &content) 
+createAdapterFromString(const std::string &content)
 {
     StructureAdapterPtr base = createStructureAdapterFromString(content);
 
     auto rv = std::dynamic_pointer_cast<Adapter>(base);
-    if (!rv) 
+    if (!rv)
     {
         throw nb::type_error(
             "serialized content does not contain the requested adapter type"

--- a/src/extensions/srreal_registry.cpp
+++ b/src/extensions/srreal_registry.cpp
@@ -16,27 +16,26 @@
 *
 *****************************************************************************/
 
-#include <boost/python/object.hpp>
-#include <boost/python/import.hpp>
+#include <nanobind/nanobind.h>
+
+namespace nb = nanobind;
 
 namespace srrealmodule {
 
-using namespace boost::python;
-
 void register_for_cleanup(PyObject* pobj)
 {
-    object obj(borrowed(pobj));
-    object reg = import("diffpy.srreal._cleanup").attr("registerForCleanUp");
+    nb::object obj = nb::borrow(pobj);
+    nb::object reg = nb::module_::import_("diffpy.srreal._cleanup").attr("registerForCleanUp");
     reg(obj);
 }
 
 
 /// get dictionary of Python-defined docstrings for the cls class.
-object get_registry_docstrings(object& cls)
+nb::object get_registry_docstrings(nb::object& cls)
 {
-    object mod = import("diffpy.srreal._docstrings");
-    object getdocs = mod.attr("get_registry_docstrings");
-    object rv = getdocs(cls);
+    nb::object mod = nb::module_::import_("diffpy.srreal._docstrings");
+    nb::object getdocs = mod.attr("get_registry_docstrings");
+    nb::object rv = getdocs(cls);
     return rv;
 }
 

--- a/src/extensions/srreal_registry.hpp
+++ b/src/extensions/srreal_registry.hpp
@@ -21,6 +21,7 @@
 
 #include <nanobind/nanobind.h>
 #include <nanobind/stl/shared_ptr.h>
+#include <nanobind/stl/string.h>
 
 namespace nb = nanobind;
 

--- a/src/extensions/srreal_registry.hpp
+++ b/src/extensions/srreal_registry.hpp
@@ -20,6 +20,7 @@
 #define SRREAL_REGISTRY_HPP_INCLUDED
 
 #include <nanobind/nanobind.h>
+#include <nanobind/stl/shared_ptr.h>
 
 namespace nb = nanobind;
 

--- a/src/extensions/srreal_registry.hpp
+++ b/src/extensions/srreal_registry.hpp
@@ -19,8 +19,9 @@
 #ifndef SRREAL_REGISTRY_HPP_INCLUDED
 #define SRREAL_REGISTRY_HPP_INCLUDED
 
-#include <boost/python/object.hpp>
-#include <boost/python/extract.hpp>
+#include <nanobind/nanobind.h>
+
+namespace nb = nanobind;
 
 namespace srrealmodule {
 
@@ -44,9 +45,9 @@ class wrapper_registry_configurator
         /// the fetch method should be called only from the wrapped method
         /// create() to remember pointers to the last Python object and
         /// the C++ instance that it wraps.
-        TSharedPtr fetch(::boost::python::object& obj) const
+        TSharedPtr fetch(nb::object& obj) const
         {
-            TSharedPtr p = ::boost::python::extract<TSharedPtr>(obj);
+            TSharedPtr p = nb::cast<TSharedPtr>(obj);
             mcptr = p.get();
             mpyptr = obj.ptr();
             return p;
@@ -73,73 +74,69 @@ class wrapper_registry_configurator
 
 
 /// retrieve a dictionary of Python-defined docstrings for the cls class.
-::boost::python::object get_registry_docstrings(::boost::python::object& cls);
+nb::object get_registry_docstrings(nb::object& cls);
 
 
 /// helper wrapper functions for return value conversions.
 
 template <class W>
-::boost::python::object getAliasedTypes_asdict()
+nb::object getAliasedTypes_asdict()
 {
     return convertToPythonDict(W::getAliasedTypes());
 }
 
 template <class W>
-::boost::python::object getRegisteredTypes_asset()
+nb::object getRegisteredTypes_asset()
 {
     return convertToPythonSet(W::getRegisteredTypes());
 }
 
 
 /// template function that wraps HasClassRegistry methods
-template <class C>
-C& wrap_registry_methods(C& boostpythonclass)
+template <class C, class... Extra>
+nb::class_<C, Extra...>& wrap_registry_methods(nb::class_<C, Extra...>& cls)
 {
-    namespace bp = boost::python;
-    using namespace boost::python;
-    typedef typename C::wrapped_type::base B;
-    typedef extract<const char*> CString;
     // get docstrings for the class registry methods.
-    object d = get_registry_docstrings(boostpythonclass);
-    const char* doc_create = CString(d["create"]);
-    const char* doc_clone = CString(d["clone"]);
-    const char* doc_type = CString(d["type"]);
-    const char* doc__registerThisType = CString(d["_registerThisType"]);
-    const char* doc__aliasType = CString(d["_aliasType"]);
-    const char* doc__deregisterType = CString(d["_deregisterType"]);
-    const char* doc_createByType = CString(d["createByType"]);
-    const char* doc_isRegisteredType = CString(d["isRegisteredType"]);
-    const char* doc_getAliasedTypes = CString(d["getAliasedTypes"]);
-    const char* doc_getRegisteredTypes = CString(d["getRegisteredTypes"]);
+    nb::object d = get_registry_docstrings(cls);
+    std::string doc_create = nb::cast<std::string>(d["create"]);
+    std::string doc_clone = nb::cast<std::string>(d["clone"]);
+    std::string doc_type = nb::cast<std::string>(d["type"]);
+    std::string doc__registerThisType = nb::cast<std::string>(d["_registerThisType"]);
+    std::string doc__aliasType = nb::cast<std::string>(d["_aliasType"]);
+    std::string doc__deregisterType = nb::cast<std::string>(d["_deregisterType"]);
+    std::string doc_createByType = nb::cast<std::string>(d["createByType"]);
+    std::string doc_isRegisteredType = nb::cast<std::string>(d["isRegisteredType"]);
+    std::string doc_getAliasedTypes = nb::cast<std::string>(d["getAliasedTypes"]);
+    std::string doc_getRegisteredTypes = nb::cast<std::string>(d["getRegisteredTypes"]);
     // define the class registry related methods.
-    boostpythonclass
-        .def("create", &B::create, doc_create)
-        .def("clone", &B::clone, doc_clone)
-        .def("type", &B::type,
-                return_value_policy<copy_const_reference>(),
-                doc_type)
-        .def("_registerThisType", &B::registerThisType,
-                doc__registerThisType)
-        .def("_aliasType", &B::aliasType,
-                (bp::arg("tp"), bp::arg("alias")), doc__aliasType)
-        .staticmethod("_aliasType")
-        .def("_deregisterType", &B::deregisterType,
-                bp::arg("tp"), doc__deregisterType)
-        .staticmethod("_deregisterType")
-        .def("createByType", &B::createByType,
-                bp::arg("tp"), doc_createByType)
-        .staticmethod("createByType")
-        .def("isRegisteredType", &B::isRegisteredType,
-                bp::arg("tp"), doc_isRegisteredType)
-        .staticmethod("isRegisteredType")
-        .def("getAliasedTypes", getAliasedTypes_asdict<B>,
-                doc_getAliasedTypes)
-        .staticmethod("getAliasedTypes")
-        .def("getRegisteredTypes", getRegisteredTypes_asset<B>,
-                doc_getRegisteredTypes)
-        .staticmethod("getRegisteredTypes")
+    cls
+        .def("create", &C::create,
+                doc_create.c_str())
+        .def("clone", &C::clone,
+                doc_clone.c_str())
+        .def("type", &C::type,
+                nb::rv_policy::copy,
+                doc_type.c_str())
+        .def("_registerThisType", &C::registerThisType,
+                doc__registerThisType.c_str())
+        .def_static("_aliasType", &C::aliasType,
+                nb::arg("tp"), nb::arg("alias"),
+                doc__aliasType.c_str())
+        .def_static("_deregisterType", &C::deregisterType,
+                nb::arg("tp"),
+                doc__deregisterType.c_str())
+        .def_static("createByType", &C::createByType,
+                nb::arg("tp"),
+                doc_createByType.c_str())
+        .def_static("isRegisteredType", &C::isRegisteredType,
+                nb::arg("tp"),
+                doc_isRegisteredType.c_str())
+        .def_static("getAliasedTypes", &getAliasedTypes_asdict<C>,
+                doc_getAliasedTypes.c_str())
+        .def_static("getRegisteredTypes", &getRegisteredTypes_asset<C>,
+                doc_getRegisteredTypes.c_str())
         ;
-    return boostpythonclass;
+    return cls;
 }
 
 

--- a/src/extensions/srreal_validators.cpp
+++ b/src/extensions/srreal_validators.cpp
@@ -16,21 +16,15 @@
 *
 *****************************************************************************/
 
-#include <boost/python/errors.hpp>
-#include <boost/python/import.hpp>
-
 #include "srreal_validators.hpp"
 
 namespace srrealmodule {
-
-using namespace boost::python;
 
 void ensure_index_bounds(int idx, int lo, int hi)
 {
     if (idx < lo || idx >= hi)
     {
-        PyErr_SetString(PyExc_IndexError, "Index out of range.");
-        throw_error_already_set();
+        throw nb::index_error("Index out of range.");
     }
 }
 
@@ -39,19 +33,17 @@ void ensure_non_negative(int value)
 {
     if (value < 0)
     {
-        PyErr_SetString(PyExc_ValueError, "Value cannot be negative.");
-        throw_error_already_set();
+        throw nb::value_error("Value cannot be negative.");
     }
 }
 
 
-bool isiterable(boost::python::object obj)
+bool isiterable(nb::object obj)
 {
-    using boost::python::import;
 #if PY_MAJOR_VERSION >= 3
-    object Iterable = import("collections.abc").attr("Iterable");
+    nb::object Iterable = nb::module_::import_("collections.abc").attr("Iterable");
 #else
-    object Iterable = import("collections").attr("Iterable");
+    nb::object Iterable = nb::module_::import_("collections").attr("Iterable");
 #endif
     bool rv = (1 == PyObject_IsInstance(obj.ptr(), Iterable.ptr()));
     return rv;

--- a/src/extensions/srreal_validators.hpp
+++ b/src/extensions/srreal_validators.hpp
@@ -19,11 +19,15 @@
 #ifndef SRREAL_VALIDATORS_HPP_INCLUDED
 #define SRREAL_VALIDATORS_HPP_INCLUDED
 
+#include <nanobind/nanobind.h>
+
+namespace nb = nanobind;
+
 namespace srrealmodule {
 
 void ensure_index_bounds(int idx, int lo, int hi);
 void ensure_non_negative(int value);
-bool isiterable(boost::python::object obj);
+bool isiterable(nb::object obj);
 
 }   // namespace srrealmodule
 

--- a/src/extensions/wrap_AtomRadiiTable.cpp
+++ b/src/extensions/wrap_AtomRadiiTable.cpp
@@ -296,7 +296,7 @@ void wrap_AtomRadiiTable(nb::module_& m)
                 &ConstantRadiiTable::getDefault,
                 doc_ConstantRadiiTable_getDefault)
         ;
-        SerializationPickleSuite<ConstantRadiiTable, DICT_IGNORE>::bind(constantradiitable);
+        SerializationPickleSuite<ConstantRadiiTable, DICT_DISCARD>::bind(constantradiitable);
 
 }
 

--- a/src/extensions/wrap_AtomRadiiTable.cpp
+++ b/src/extensions/wrap_AtomRadiiTable.cpp
@@ -151,7 +151,8 @@ DECLARE_PYDICT_METHOD_WRAPPER(getAllCustom, getAllCustom_asdict)
 // Helper class for overloads of AtomRadiiTable methods from Python
 
 class AtomRadiiTableWrap :
-    public AtomRadiiTable
+    public AtomRadiiTable,
+    public PythonTrampolineTag
 {
     public:
 
@@ -269,7 +270,10 @@ void wrap_AtomRadiiTable(nb::module_& m)
                 &AtomRadiiTable::toString, nb::arg("separator")=",",
                 doc_AtomRadiiTable_toString)
         ;
-        SerializationPickleSuite<AtomRadiiTable, DICT_PICKLE>::bind(atomradiitable);
+        SerializationPickleSuite<
+            AtomRadiiTable,
+            DICT_PICKLE,
+            AtomRadiiTableWrap>::bind(atomradiitable);
 
     nb::class_<ConstantRadiiTable, AtomRadiiTable>
         constantradiitable(m, "ConstantRadiiTable", doc_ConstantRadiiTable);

--- a/src/extensions/wrap_AtomRadiiTable.cpp
+++ b/src/extensions/wrap_AtomRadiiTable.cpp
@@ -275,6 +275,7 @@ void wrap_AtomRadiiTable(nb::module_& m)
         constantradiitable(m, "ConstantRadiiTable", doc_ConstantRadiiTable);
         // docstring updates
     constantradiitable
+        .def(nb::init<>())
         .def("create", &ConstantRadiiTable::create,
                 doc_ConstantRadiiTable_create)
         .def("clone", &ConstantRadiiTable::clone,

--- a/src/extensions/wrap_AtomRadiiTable.cpp
+++ b/src/extensions/wrap_AtomRadiiTable.cpp
@@ -16,9 +16,9 @@
 *
 *****************************************************************************/
 
-#include <boost/python/class.hpp>
-#include <boost/python/copy_const_reference.hpp>
-#include <boost/python/register_ptr_to_python.hpp>
+#include <nanobind/nanobind.h>
+#include <nanobind/trampoline.h>
+#include <nanobind/operators.h>
 
 #include "srreal_converters.hpp"
 #include "srreal_pickling.hpp"
@@ -27,10 +27,11 @@
 #include <diffpy/srreal/AtomRadiiTable.hpp>
 #include <diffpy/srreal/ConstantRadiiTable.hpp>
 
+namespace nb = nanobind;
+
 namespace srrealmodule {
 namespace nswrap_AtomRadiiTable {
 
-using namespace boost::python;
 using namespace diffpy::srreal;
 
 // docstrings ----------------------------------------------------------------
@@ -150,43 +151,64 @@ DECLARE_PYDICT_METHOD_WRAPPER(getAllCustom, getAllCustom_asdict)
 // Helper class for overloads of AtomRadiiTable methods from Python
 
 class AtomRadiiTableWrap :
-    public AtomRadiiTable,
-    public wrapper_srreal<AtomRadiiTable>
+    public AtomRadiiTable
 {
     public:
 
+        NB_TRAMPOLINE(AtomRadiiTable, 4);
+
         // HasClassRegistry methods
 
-        AtomRadiiTablePtr create() const
+        AtomRadiiTablePtr create() const override
         {
-            object rv = this->get_pure_virtual_override("create")();
+            nb::gil_scoped_acquire gil;
+            nb::detail::ticket ticket(nb_trampoline, "create", true);
+
+            if (!ticket.key.is_valid()) 
+            {
+                throw nb::type_error(
+                    "pure virtual method AtomRadiiTable.create() called"
+                );
+            }
+            
+            nb::object rv = nb_trampoline.base().attr(ticket.key)();
             return mconfigurator.fetch(rv);
         }
 
-        AtomRadiiTablePtr clone() const
+        AtomRadiiTablePtr clone() const override
         {
-            return this->get_pure_virtual_override("clone")();
+            NB_OVERRIDE_PURE(clone);
         }
 
-        const std::string& type() const
+        const std::string& type() const override
         {
-            object tp = this->get_pure_virtual_override("type")();
-            mtype = extract<std::string>(tp);
+            nb::gil_scoped_acquire gil;
+            nb::detail::ticket ticket(nb_trampoline, "type", true);
+
+            if (!ticket.key.is_valid()) 
+            {
+                throw nb::type_error(
+                    "pure virtual method AtomRadiiTable.type() called"
+                );
+            }
+
+            nb::object tp = nb_trampoline.base().attr(ticket.key)();
+            mtype = nb::cast<std::string>(tp);
             return mtype;
         }
 
         // own methods
 
-        double standardLookup(const std::string& smbl) const
+        double standardLookup(const std::string& smbl) const override
         {
-            return this->get_pure_virtual_override("_standardLookup")(smbl);
+            NB_OVERRIDE_PURE_NAME("_standardLookup", standardLookup, smbl);
         }
 
     protected:
 
         // HasClassRegistry method
 
-        void setupRegisteredObject(AtomRadiiTablePtr p) const
+        void setupRegisteredObject(AtomRadiiTablePtr p) const override
         {
             mconfigurator.setup(p);
         }
@@ -211,29 +233,31 @@ class AtomRadiiTableWrap :
 
 // Wrapper definition --------------------------------------------------------
 
-void wrap_AtomRadiiTable()
+void wrap_AtomRadiiTable(nb::module_& m)
 {
     using namespace nswrap_AtomRadiiTable;
-    using boost::noncopyable;
 
-    class_<AtomRadiiTableWrap, noncopyable>
-        atomradiitable("AtomRadiiTable", doc_AtomRadiiTable);
+    nb::class_<AtomRadiiTable, AtomRadiiTableWrap>
+        atomradiitable(m, "AtomRadiiTable", doc_AtomRadiiTable,
+                   nb::dynamic_attr());
     wrap_registry_methods(atomradiitable)
+        .def(nb::init<>())
         .def("lookup",
-                &AtomRadiiTable::lookup, arg("smbl"),
+                &AtomRadiiTable::lookup, nb::arg("smbl"),
                 doc_AtomRadiiTable_lookup)
         .def("_standardLookup",
                 &AtomRadiiTable::standardLookup,
-                arg("smbl"), doc_AtomRadiiTable__standardLookup)
+                nb::arg("smbl"), doc_AtomRadiiTable__standardLookup)
         .def("setCustom",
                 &AtomRadiiTable::setCustom,
-                (arg("smbl"), arg("radius")),
+                nb::arg("smbl"), nb::arg("radius"),
                 doc_AtomRadiiTable_setCustom)
         .def("fromString",
                 &AtomRadiiTable::fromString,
+                nb::arg("s"),
                 doc_AtomRadiiTable_fromString)
         .def("resetCustom",
-                &AtomRadiiTable::resetCustom, arg("smbl"),
+                &AtomRadiiTable::resetCustom, nb::arg("smbl"),
                 doc_AtomRadiiTable_resetCustom)
         .def("resetAll",
                 &AtomRadiiTable::resetAll,
@@ -242,33 +266,32 @@ void wrap_AtomRadiiTable()
                 getAllCustom_asdict<AtomRadiiTable>,
                 doc_AtomRadiiTable_getAllCustom)
         .def("toString",
-                &AtomRadiiTable::toString, arg("separator")=",",
+                &AtomRadiiTable::toString, nb::arg("separator")=",",
                 doc_AtomRadiiTable_toString)
-        .def_pickle(SerializationPickleSuite<AtomRadiiTable,DICT_PICKLE>())
         ;
+        SerializationPickleSuite<AtomRadiiTable, DICT_PICKLE>::bind(atomradiitable);
 
-    register_ptr_to_python<AtomRadiiTablePtr>();
-
-    class_<ConstantRadiiTable, bases<AtomRadiiTable> >(
-            "ConstantRadiiTable", doc_ConstantRadiiTable)
+    nb::class_<ConstantRadiiTable, AtomRadiiTable>
+        constantradiitable(m, "ConstantRadiiTable", doc_ConstantRadiiTable);
         // docstring updates
+    constantradiitable
         .def("create", &ConstantRadiiTable::create,
                 doc_ConstantRadiiTable_create)
         .def("clone", &ConstantRadiiTable::clone,
                 doc_ConstantRadiiTable_clone)
         .def("_standardLookup",
                 &ConstantRadiiTable::standardLookup,
-                arg("smbl"), doc_ConstantRadiiTable__standardLookup)
+                nb::arg("smbl"), doc_ConstantRadiiTable__standardLookup)
         // own methods
         .def("setDefault",
                 &ConstantRadiiTable::setDefault,
-                arg("radius"),
+                nb::arg("radius"),
                 doc_ConstantRadiiTable_setDefault)
         .def("getDefault",
                 &ConstantRadiiTable::getDefault,
                 doc_ConstantRadiiTable_getDefault)
-        .def_pickle(SerializationPickleSuite<ConstantRadiiTable,DICT_IGNORE>())
         ;
+        SerializationPickleSuite<ConstantRadiiTable, DICT_IGNORE>::bind(constantradiitable);
 
 }
 

--- a/src/extensions/wrap_AtomRadiiTable.cpp
+++ b/src/extensions/wrap_AtomRadiiTable.cpp
@@ -165,13 +165,13 @@ class AtomRadiiTableWrap :
             nb::gil_scoped_acquire gil;
             nb::detail::ticket ticket(nb_trampoline, "create", true);
 
-            if (!ticket.key.is_valid()) 
+            if (!ticket.key.is_valid())
             {
                 throw nb::type_error(
                     "pure virtual method AtomRadiiTable.create() called"
                 );
             }
-            
+
             nb::object rv = nb_trampoline.base().attr(ticket.key)();
             return mconfigurator.fetch(rv);
         }
@@ -186,7 +186,7 @@ class AtomRadiiTableWrap :
             nb::gil_scoped_acquire gil;
             nb::detail::ticket ticket(nb_trampoline, "type", true);
 
-            if (!ticket.key.is_valid()) 
+            if (!ticket.key.is_valid())
             {
                 throw nb::type_error(
                     "pure virtual method AtomRadiiTable.type() called"

--- a/src/extensions/wrap_AtomicStructureAdapter.cpp
+++ b/src/extensions/wrap_AtomicStructureAdapter.cpp
@@ -325,7 +325,9 @@ void set_uc(Atom& a, nb::object value)
 // template wrapper class for overloading of clone and _customPQConfig
 
 template <class T>
-class MakeWrapper : public T
+class MakeWrapper :
+    public T,
+    public PythonTrampolineTag
 {
     public:
 
@@ -687,7 +689,9 @@ void wrap_AtomicStructureAdapter(nb::module_& m)
         .def("reserve", atomadapter_reserve,
                 nb::arg("sz"), doc_AtomicStructureAdapter_reserve)
         ;
-    StructureAdapterPickleSuite<AtomicStructureAdapter>::bind(adapter_class);
+    StructureAdapterPickleSuite<
+        AtomicStructureAdapter,
+        AtomicStructureAdapterWrap>::bind(adapter_class);
 
     // class PeriodicStructureAdapter
     nb::class_<PeriodicStructureAdapter,
@@ -726,7 +730,9 @@ void wrap_AtomicStructureAdapter(nb::module_& m)
         .def("toFractional", &PeriodicStructureAdapter::toFractional,
                 nb::arg("atom"), doc_PeriodicStructureAdapter_toFractional)
         ;
-    StructureAdapterPickleSuite<PeriodicStructureAdapter>::bind(periodic_class);
+    StructureAdapterPickleSuite<
+        PeriodicStructureAdapter,
+        PeriodicStructureAdapterWrap>::bind(periodic_class);
 
     // class CrystalStructureAdapter
     nb::class_<CrystalStructureAdapter,
@@ -777,7 +783,9 @@ void wrap_AtomicStructureAdapter(nb::module_& m)
                 &CrystalStructureAdapter::updateSymmetryPositions,
                 doc_CrystalStructureAdapter_updateSymmetryPositions)
         ;
-    StructureAdapterPickleSuite<CrystalStructureAdapter>::bind(crystal_class);
+    StructureAdapterPickleSuite<
+        CrystalStructureAdapter,
+        CrystalStructureAdapterWrap>::bind(crystal_class);
 
 }
 

--- a/src/extensions/wrap_AtomicStructureAdapter.cpp
+++ b/src/extensions/wrap_AtomicStructureAdapter.cpp
@@ -390,7 +390,7 @@ class MakeWrapper : public T, public wrapper_srreal<T>
 // Wrapper helpers for class AtomicStructureAdapter
 
 typedef MakeWrapper<AtomicStructureAdapter> AtomicStructureAdapterWrap;
-typedef boost::shared_ptr<AtomicStructureAdapterWrap> AtomicStructureAdapterWrapPtr;
+typedef std::shared_ptr<AtomicStructureAdapterWrap> AtomicStructureAdapterWrapPtr;
 
 class atomadapter_indexing : public vector_indexing_suite<
                          AtomicStructureAdapter, false, atomadapter_indexing>
@@ -406,7 +406,7 @@ class atomadapter_indexing : public vector_indexing_suite<
             // of any additional structure data.
             StructureAdapterPtr rv = container.clone();
             AtomicStructureAdapterPtr rva;
-            rva = boost::static_pointer_cast<AtomicStructureAdapter>(rv);
+            rva = std::static_pointer_cast<AtomicStructureAdapter>(rv);
             // handle index ranges for a valid and empty slice
             if (from <= to)
             {
@@ -458,7 +458,7 @@ void atomadapter_reserve(AtomicStructureAdapter& adpt, int sz)
 // Wrapper helpers for class PeriodicStructureAdapter
 
 typedef MakeWrapper<PeriodicStructureAdapter> PeriodicStructureAdapterWrap;
-typedef boost::shared_ptr<PeriodicStructureAdapterWrap> PeriodicStructureAdapterWrapPtr;
+typedef std::shared_ptr<PeriodicStructureAdapterWrap> PeriodicStructureAdapterWrapPtr;
 
 python::tuple periodicadapter_getlatpar(const PeriodicStructureAdapter& adpt)
 {
@@ -471,7 +471,7 @@ python::tuple periodicadapter_getlatpar(const PeriodicStructureAdapter& adpt)
 // Wrapper helpers for class CrystalStructureAdapter
 
 typedef MakeWrapper<CrystalStructureAdapter> CrystalStructureAdapterWrap;
-typedef boost::shared_ptr<CrystalStructureAdapterWrap> CrystalStructureAdapterWrapPtr;
+typedef std::shared_ptr<CrystalStructureAdapterWrap> CrystalStructureAdapterWrapPtr;
 
 double
 crystaladapter_getsymmetryprecision(const CrystalStructureAdapter& adpt)

--- a/src/extensions/wrap_AtomicStructureAdapter.cpp
+++ b/src/extensions/wrap_AtomicStructureAdapter.cpp
@@ -303,7 +303,10 @@ bool get_anisotropy(const Atom& a)
 
 void set_anisotropy(Atom& a, nb::object value)
 {
-    a.anisotropy = bool(value);
+    int truth = PyObject_IsTrue(value.ptr());
+    if (truth < 0)
+        nb::raise_python_error();
+    a.anisotropy = truth != 0;
 }
 
 
@@ -640,7 +643,7 @@ void wrap_AtomicStructureAdapter(nb::module_& m)
         .def_prop_rw("uc13", get_uc<0, 2>, set_uc<0, 2>, doc_Atom_uijc)
         .def_prop_rw("uc23", get_uc<1, 2>, set_uc<1, 2>, doc_Atom_uijc)
         ;
-        SerializationPickleSuite<Atom, DICT_IGNORE>::bind(atom_class);
+        SerializationPickleSuite<Atom, DICT_GUARD>::bind(atom_class);
 
     nb::class_<AtomAdapterIterator>(m, "_AtomicStructureAdapterIterator")
         .def("__iter__", [](AtomAdapterIterator& it) -> AtomAdapterIterator& {

--- a/src/extensions/wrap_AtomicStructureAdapter.cpp
+++ b/src/extensions/wrap_AtomicStructureAdapter.cpp
@@ -19,8 +19,9 @@
 *
 *****************************************************************************/
 
-#include <boost/python/class.hpp>
-#include <boost/python/suite/indexing/vector_indexing_suite.hpp>
+#include <nanobind/nanobind.h>
+#include <nanobind/trampoline.h>
+#include <nanobind/operators.h>
 
 #include <diffpy/srreal/AtomicStructureAdapter.hpp>
 #include <diffpy/srreal/PeriodicStructureAdapter.hpp>
@@ -36,12 +37,10 @@
 namespace srrealmodule {
 
 // declarations
-void sync_StructureDifference(boost::python::object obj);
+void sync_StructureDifference(nb::object obj);
 
 namespace nswrap_AtomicStructureAdapter {
 
-using namespace boost;
-using namespace boost::python;
 using namespace diffpy::srreal;
 
 // docstrings ----------------------------------------------------------------
@@ -251,23 +250,23 @@ implicitly called from createBondGenerator.\n\
 
 // Wrapper helpers for the class Atom
 
-object get_xyz_cartn(Atom& a)
+nb::object get_xyz_cartn(Atom& a)
 {
     return viewAsNumPyArray(a.xyz_cartn);
 }
 
-void set_xyz_cartn(Atom& a, object value)
+void set_xyz_cartn(Atom& a, nb::object value)
 {
     assignR3Vector(a.xyz_cartn, value);
 }
 
 
-object get_uij_cartn(Atom& a)
+nb::object get_uij_cartn(Atom& a)
 {
     return viewAsNumPyArray(a.uij_cartn);
 }
 
-void set_uij_cartn(Atom& a, object& value)
+void set_uij_cartn(Atom& a, nb::object& value)
 {
     assignR3Matrix(a.uij_cartn, value);
 }
@@ -280,7 +279,7 @@ double get_xyz(const Atom& a)
 }
 
 template <const int i>
-void set_xyz(Atom& a, object value)
+void set_xyz(Atom& a, nb::object value)
 {
     a.xyz_cartn[i] = extractdouble(value);
 }
@@ -291,7 +290,7 @@ double get_occ(const Atom& a)
     return a.occupancy;
 }
 
-void set_occ(Atom& a, object value)
+void set_occ(Atom& a, nb::object value)
 {
     a.occupancy = extractdouble(value);
 }
@@ -302,7 +301,7 @@ bool get_anisotropy(const Atom& a)
     return a.anisotropy;
 }
 
-void set_anisotropy(Atom& a, object value)
+void set_anisotropy(Atom& a, nb::object value)
 {
     a.anisotropy = bool(value);
 }
@@ -316,7 +315,7 @@ double get_uc(const Atom& a)
 }
 
 template <const int i, const int j>
-void set_uc(Atom& a, object value)
+void set_uc(Atom& a, nb::object value)
 {
     assert(i <= j);
     a.uij_cartn(i, j) = extractdouble(value);
@@ -326,15 +325,15 @@ void set_uc(Atom& a, object value)
 // template wrapper class for overloading of clone and _customPQConfig
 
 template <class T>
-class MakeWrapper : public T, public wrapper_srreal<T>
+class MakeWrapper : public T
 {
     public:
 
-        StructureAdapterPtr clone() const
+        NB_TRAMPOLINE(T, 3);
+
+        StructureAdapterPtr clone() const override
         {
-            override f = this->get_override("clone");
-            if (f)  return f();
-            else  return this->default_clone();
+            NB_OVERRIDE(clone);
         }
 
         StructureAdapterPtr default_clone() const
@@ -343,11 +342,9 @@ class MakeWrapper : public T, public wrapper_srreal<T>
         }
 
 
-        void customPQConfig(PairQuantity* pq) const
+        void customPQConfig(PairQuantity* pq) const override
         {
-            override f = this->get_override("_customPQConfig");
-            if (f)  f(ptr(pq));
-            else    this->default_customPQConfig(pq);
+            NB_OVERRIDE_NAME("_customPQConfig", customPQConfig, pq);
         }
 
         void default_customPQConfig(PairQuantity* pq) const
@@ -356,15 +353,16 @@ class MakeWrapper : public T, public wrapper_srreal<T>
         }
 
 
-        StructureDifference diff(StructureAdapterConstPtr other) const
+        StructureDifference diff(StructureAdapterConstPtr other) const override
         {
-            override f = this->get_override("diff");
-            if (f)
+            nb::gil_scoped_acquire gil;
+            nb::detail::ticket ticket(nb_trampoline, "diff", false);
+            if (ticket.key.is_valid()) 
             {
-                python::object sdobj = f(other);
+                nb::object sdobj = nb_trampoline.base().attr(ticket.key)(other);
                 sync_StructureDifference(sdobj);
                 StructureDifference& sd =
-                    python::extract<StructureDifference&>(sdobj);
+                    nb::cast<StructureDifference&>(sdobj);
                 return sd;
             }
             return this->default_diff(other);
@@ -391,34 +389,95 @@ class MakeWrapper : public T, public wrapper_srreal<T>
 
 typedef MakeWrapper<AtomicStructureAdapter> AtomicStructureAdapterWrap;
 typedef std::shared_ptr<AtomicStructureAdapterWrap> AtomicStructureAdapterWrapPtr;
+typedef AtomicStructureAdapter::value_type data_type;
 
-class atomadapter_indexing : public vector_indexing_suite<
-                         AtomicStructureAdapter, false, atomadapter_indexing>
+class AtomAdapterIterator
+{
+    public:
+
+        explicit AtomAdapterIterator(AtomicStructureAdapter& container) :
+            mcontainer(&container), midx(0)
+        { }
+
+        Atom& next()
+        {
+            if (midx >= mcontainer->size())
+            {
+                throw nb::stop_iteration();
+            }
+            return (*mcontainer)[static_cast<int>(midx++)];
+        }
+
+    private:
+
+        AtomicStructureAdapter* mcontainer;
+        size_t midx;
+
+};
+
+class atomadapter_indexing : public nb::def_visitor<atomadapter_indexing>
 {
     public:
 
         typedef AtomicStructureAdapter Container;
 
-        static object
-        get_slice(Container& container, index_type from, index_type to)
+        
+        template <typename Class, typename... Extra>
+        void execute(Class& cls, const Extra&...)
         {
+            cls
+                .def("__len__", [](const Container& container) {
+                    return container.size();
+                })
+                .def("__getitem__",
+                    [](Container& container, int idx) -> Atom& {
+                        return container[normalize_index(container, idx)];
+                    },
+                    nb::rv_policy::reference_internal)
+                .def("__getitem__", get_slice)
+                .def("__iter__",
+                    [](Container& container) {
+                        return AtomAdapterIterator(container);
+                    },
+                    nb::keep_alive<0,1>())
+                .def("__setitem__",
+                    [](Container& container, int idx, const Atom& atom) {
+                        container[normalize_index(container, idx)] = atom;
+                    })
+                .def("__delitem__",
+                    [](Container& container, int idx) {
+                        container.erase(normalize_index(container, idx));
+                    })
+                ;
+        }
+
+
+        static nb::object
+        get_slice(Container& container, nb::slice slice)
+        {
+            const size_t n = container.countSites();
+            auto [from, to, step, slice_len] = slice.compute(n);
             // make sure slice is of a correct type and has a copy
             // of any additional structure data.
             StructureAdapterPtr rv = container.clone();
-            AtomicStructureAdapterPtr rva;
-            rva = std::static_pointer_cast<AtomicStructureAdapter>(rv);
+            AtomicStructureAdapterPtr rva = 
+                std::static_pointer_cast<AtomicStructureAdapter>(rv);
+            rva->clear();
             // handle index ranges for a valid and empty slice
-            if (from <= to)
+            Py_ssize_t idx = from;
+            for (size_t i = 0; i < slice_len; ++i, idx += step)
             {
-                rva->erase(rva->begin() + to, rva->end());
-                rva->erase(rva->begin(), rva->begin() + from);
+                rva->append(container[static_cast<int>(idx)]);
             }
-            else  rva->clear();
+
             // save memory by making a new copy for short slices
-            const index_type halflength = rva->countSites() / 2;
-            const bool longslice = ((to - from) > halflength);
-            object pyrv(longslice ? rv : rv->clone());
-            return pyrv;
+            const bool longslice = slice_len > n / 2;
+            AtomicStructureAdapterPtr out =
+                longslice
+                    ? rva
+                    : std::static_pointer_cast<AtomicStructureAdapter>(rva->clone());
+
+            return nb::cast(out);
         }
 
 
@@ -428,6 +487,14 @@ class atomadapter_indexing : public vector_indexing_suite<
             container.append(v);
         }
 
+    private:
+
+    
+        static int normalize_index(const Container& container, int idx)
+        {
+            ensure_index_bounds(idx, -int(container.size()), container.size());
+            return (idx >= 0) ? idx : int(container.size()) + idx;
+        }
 };
 
 
@@ -460,10 +527,10 @@ void atomadapter_reserve(AtomicStructureAdapter& adpt, int sz)
 typedef MakeWrapper<PeriodicStructureAdapter> PeriodicStructureAdapterWrap;
 typedef std::shared_ptr<PeriodicStructureAdapterWrap> PeriodicStructureAdapterWrapPtr;
 
-python::tuple periodicadapter_getlatpar(const PeriodicStructureAdapter& adpt)
+nb::tuple periodicadapter_getlatpar(const PeriodicStructureAdapter& adpt)
 {
     const Lattice& L = adpt.getLattice();
-    python::tuple rv = python::make_tuple(
+    nb::tuple rv = nb::make_tuple(
             L.a(), L.b(), L.c(), L.alpha(), L.beta(), L.gamma());
     return rv;
 }
@@ -481,7 +548,7 @@ crystaladapter_getsymmetryprecision(const CrystalStructureAdapter& adpt)
 
 
 void crystaladapter_addsymop(CrystalStructureAdapter& adpt,
-        python::object R, python::object t)
+        nb::object R, nb::object t)
 {
     static SymOpRotTrans op;
     assignR3Matrix(op.R, R);
@@ -490,20 +557,19 @@ void crystaladapter_addsymop(CrystalStructureAdapter& adpt,
 }
 
 
-python::tuple
+nb::tuple
 crystaladapter_getsymop(const CrystalStructureAdapter& adpt, int idx)
 {
     ensure_index_bounds(idx, 0, adpt.countSymOps());
     const SymOpRotTrans& op = adpt.getSymOp(idx);
-    python::tuple rv = python::make_tuple(
+    return nb::make_tuple(
             convertToNumPyArray(op.R), convertToNumPyArray(op.t));
-    return rv;
 }
 
 
 DECLARE_PYLIST_METHOD_WRAPPER1(getEquivalentAtoms, getEquivalentAtoms_aslist)
 
-python::object crystaladapter_getequivalentatoms(
+nb::object crystaladapter_getequivalentatoms(
         const CrystalStructureAdapter& adpt, int idx)
 {
     ensure_index_bounds(idx, 0, adpt.countSymOps());
@@ -523,150 +589,171 @@ extern const char* doc_StructureAdapter_diff;
 
 // Wrapper definitions -------------------------------------------------------
 
-void wrap_AtomicStructureAdapter()
+void wrap_AtomicStructureAdapter(nb::module_& m)
 {
-    namespace bp = boost::python;
     using namespace nswrap_AtomicStructureAdapter;
     using diffpy::srreal::hash_value;
 
     // class Atom
-    class_<Atom> atom_class("Atom", doc_Atom);
+    nb::class_<Atom> atom_class(m, "Atom", doc_Atom);
     // first define copy constructor and property helper methods
     atom_class
-        .def(init<const Atom&>(bp::arg("atom"), doc_Atom_init_copy))
-        .def(self == self)
-        .def(self != self)
-        .def(self < self)
-        .def(self > self)
-        .def(self <= self)
-        .def(self >= self)
-        .def("__hash__", hash_value)
+        .def(nb::init<>())
+        .def(nb::init<const Atom&>(), nb::arg("atom"), doc_Atom_init_copy)
+        .def(nb::self == nb::self)
+        .def(nb::self != nb::self)
+        .def(nb::self < nb::self)
+        .def(nb::self > nb::self)
+        .def(nb::self <= nb::self)
+        .def(nb::self >= nb::self)
+        .def("__hash__", static_cast<size_t (*)(const Atom&)>(&hash_value))
         .def("_get_xyz_cartn",
                 get_xyz_cartn,
-                with_custodian_and_ward_postcall<0,1>())
+                nb::keep_alive<0,1>())
         .def("_get_uij_cartn",
                 get_uij_cartn,
-                with_custodian_and_ward_postcall<0,1>())
+                nb::keep_alive<0,1>())
         ;
     // now we can finalize the Atom class interface
     atom_class
-        .def_readwrite("atomtype", &Atom::atomtype)
-        .add_property("xyz_cartn",
-                atom_class.attr("_get_xyz_cartn"),
-                set_xyz_cartn)
-        .add_property("xc", get_xyz<0>, set_xyz<0>, doc_Atom_xic)
-        .add_property("yc", get_xyz<1>, set_xyz<1>, doc_Atom_xic)
-        .add_property("zc", get_xyz<2>, set_xyz<2>, doc_Atom_xic)
-        .add_property("occupancy", get_occ, set_occ, doc_Atom_occ)
-        .add_property("anisotropy", get_anisotropy, set_anisotropy,
+        .def_rw("atomtype", &Atom::atomtype)
+        .def_prop_rw("xyz_cartn",
+                get_xyz_cartn,
+                set_xyz_cartn,
+                nb::keep_alive<0,1>())
+        .def_prop_rw("xc", get_xyz<0>, set_xyz<0>, doc_Atom_xic)
+        .def_prop_rw("yc", get_xyz<1>, set_xyz<1>, doc_Atom_xic)
+        .def_prop_rw("zc", get_xyz<2>, set_xyz<2>, doc_Atom_xic)
+        .def_prop_rw("occupancy", get_occ, set_occ, doc_Atom_occ)
+        .def_prop_rw("anisotropy", get_anisotropy, set_anisotropy,
                 doc_Atom_anisotropy)
-        .add_property("uij_cartn",
-                atom_class.attr("_get_uij_cartn"),
-                set_uij_cartn)
-        .add_property("uc11", get_uc<0, 0>, set_uc<0, 0>, doc_Atom_uijc)
-        .add_property("uc22", get_uc<1, 1>, set_uc<1, 1>, doc_Atom_uijc)
-        .add_property("uc33", get_uc<2, 2>, set_uc<2, 2>, doc_Atom_uijc)
-        .add_property("uc12", get_uc<0, 1>, set_uc<0, 1>, doc_Atom_uijc)
-        .add_property("uc13", get_uc<0, 2>, set_uc<0, 2>, doc_Atom_uijc)
-        .add_property("uc23", get_uc<1, 2>, set_uc<1, 2>, doc_Atom_uijc)
-        .def_pickle(SerializationPickleSuite<Atom,DICT_IGNORE>())
+        .def_prop_rw("uij_cartn",
+                get_uij_cartn,
+                set_uij_cartn,
+                nb::keep_alive<0,1>())
+        .def_prop_rw("uc11", get_uc<0, 0>, set_uc<0, 0>, doc_Atom_uijc)
+        .def_prop_rw("uc22", get_uc<1, 1>, set_uc<1, 1>, doc_Atom_uijc)
+        .def_prop_rw("uc33", get_uc<2, 2>, set_uc<2, 2>, doc_Atom_uijc)
+        .def_prop_rw("uc12", get_uc<0, 1>, set_uc<0, 1>, doc_Atom_uijc)
+        .def_prop_rw("uc13", get_uc<0, 2>, set_uc<0, 2>, doc_Atom_uijc)
+        .def_prop_rw("uc23", get_uc<1, 2>, set_uc<1, 2>, doc_Atom_uijc)
+        ;
+        SerializationPickleSuite<Atom, DICT_IGNORE>::bind(atom_class);
+
+    nb::class_<AtomAdapterIterator>(m, "_AtomicStructureAdapterIterator")
+        .def("__iter__", [](AtomAdapterIterator& it) -> AtomAdapterIterator& {
+            return it;
+        }, nb::rv_policy::reference_internal)
+        .def("__next__", &AtomAdapterIterator::next,
+            nb::rv_policy::reference_internal)
         ;
 
     // class AtomicStructureAdapter
-    class_<AtomicStructureAdapterWrap, bases<StructureAdapter>,
-        noncopyable, AtomicStructureAdapterWrapPtr>(
-            "AtomicStructureAdapter", doc_AtomicStructureAdapter)
-        .def("__init__", StructureAdapter_constructor(),
+    nb::class_<AtomicStructureAdapter,
+            StructureAdapter,
+            AtomicStructureAdapterWrap>
+    adapter_class(m, "AtomicStructureAdapter", doc_AtomicStructureAdapter,
+            nb::dynamic_attr());
+    adapter_class
+        .def(nb::init<>())
+        .def("__init__",
+                StructureAdapter_constructor<AtomicStructureAdapter>,
+                nb::arg("content"),
                 doc_StructureAdapter___init__fromstring)
         .def(atomadapter_indexing())
-        .def(self == self)
-        .def(self != self)
+        .def(nb::self == nb::self)
+        .def(nb::self != nb::self)
         .def("clone",
                 &AtomicStructureAdapter::clone,
-                &AtomicStructureAdapterWrap::default_clone,
                 doc_AtomicStructureAdapter_clone)
         .def("_customPQConfig",
                 &AtomicStructureAdapter::customPQConfig,
-                &AtomicStructureAdapterWrap::default_customPQConfig,
-                python::arg("pqobj"),
+                nb::arg("pqobj"),
                 doc_StructureAdapter__customPQConfig)
         .def("diff",
                 &AtomicStructureAdapter::diff,
-                &AtomicStructureAdapterWrap::default_diff,
-                python::arg("other"),
+                nb::arg("other"),
                 doc_StructureAdapter_diff)
         .def("insert", atomadapter_insert,
-                (bp::arg("index"), bp::arg("atom")),
+                nb::arg("index"), nb::arg("atom"),
                 doc_AtomicStructureAdapter_insert)
         .def("append", &AtomicStructureAdapter::append,
+                nb::arg("atom"),
                 doc_AtomicStructureAdapter_append)
         .def("pop", atomadapter_pop,
-                bp::arg("index"), doc_AtomicStructureAdapter_pop)
+                nb::arg("index"), doc_AtomicStructureAdapter_pop)
         .def("clear", &AtomicStructureAdapter::clear,
                 doc_AtomicStructureAdapter_clear)
         .def("reserve", atomadapter_reserve,
-                bp::arg("sz"), doc_AtomicStructureAdapter_reserve)
-        .def_pickle(StructureAdapterPickleSuite<AtomicStructureAdapterWrap>())
+                nb::arg("sz"), doc_AtomicStructureAdapter_reserve)
         ;
+    StructureAdapterPickleSuite<AtomicStructureAdapter>::bind(adapter_class);
 
     // class PeriodicStructureAdapter
-    class_<PeriodicStructureAdapterWrap, bases<AtomicStructureAdapter>,
-        noncopyable, PeriodicStructureAdapterWrapPtr>(
-            "PeriodicStructureAdapter", doc_PeriodicStructureAdapter)
-        .def("__init__", StructureAdapter_constructor(),
+    nb::class_<PeriodicStructureAdapter,
+            AtomicStructureAdapter,
+            PeriodicStructureAdapterWrap>
+    periodic_class(m, "PeriodicStructureAdapter", doc_PeriodicStructureAdapter,
+            nb::dynamic_attr());
+    periodic_class
+        .def(nb::init<>())
+        .def("__init__",
+                StructureAdapter_constructor<PeriodicStructureAdapter>,
+                nb::arg("content"),
                 doc_StructureAdapter___init__fromstring)
-        .def(self == self)
-        .def(self != self)
+        .def(nb::self == nb::self)
+        .def(nb::self != nb::self)
         .def("clone",
                 &PeriodicStructureAdapter::clone,
-                &PeriodicStructureAdapterWrap::default_clone,
                 doc_PeriodicStructureAdapter_clone)
         .def("_customPQConfig",
                 &PeriodicStructureAdapter::customPQConfig,
-                &PeriodicStructureAdapterWrap::default_customPQConfig,
-                python::arg("pqobj"),
+                nb::arg("pqobj"),
                 doc_StructureAdapter__customPQConfig)
         .def("diff",
                 &PeriodicStructureAdapter::diff,
-                &PeriodicStructureAdapterWrap::default_diff,
-                python::arg("other"),
+                nb::arg("other"),
                 doc_StructureAdapter_diff)
         .def("getLatPar", periodicadapter_getlatpar,
                 doc_PeriodicStructureAdapter_getLatPar)
         .def("setLatPar", &PeriodicStructureAdapter::setLatPar,
-                (bp::arg("a"), bp::arg("b"), bp::arg("c"),
-                 bp::arg("alphadeg"), bp::arg("betadeg"), bp::arg("gammadeg")),
+                nb::arg("a"), nb::arg("b"), nb::arg("c"),
+                nb::arg("alphadeg"), nb::arg("betadeg"),
+                nb::arg("gammadeg"),
                 doc_PeriodicStructureAdapter_setLatPar)
         .def("toCartesian", &PeriodicStructureAdapter::toCartesian,
-                bp::arg("atom"), doc_PeriodicStructureAdapter_toCartesian)
+                nb::arg("atom"), doc_PeriodicStructureAdapter_toCartesian)
         .def("toFractional", &PeriodicStructureAdapter::toFractional,
-                bp::arg("atom"), doc_PeriodicStructureAdapter_toFractional)
-        .def_pickle(StructureAdapterPickleSuite<PeriodicStructureAdapterWrap>())
+                nb::arg("atom"), doc_PeriodicStructureAdapter_toFractional)
         ;
+    StructureAdapterPickleSuite<PeriodicStructureAdapter>::bind(periodic_class);
 
     // class CrystalStructureAdapter
-    class_<CrystalStructureAdapterWrap, bases<PeriodicStructureAdapter>,
-        noncopyable, CrystalStructureAdapterWrapPtr>(
-            "CrystalStructureAdapter", doc_CrystalStructureAdapter)
-        .def("__init__", StructureAdapter_constructor(),
+    nb::class_<CrystalStructureAdapter,
+            PeriodicStructureAdapter,
+            CrystalStructureAdapterWrap>
+    crystal_class(m, "CrystalStructureAdapter", doc_CrystalStructureAdapter,
+            nb::dynamic_attr());
+    crystal_class
+        .def(nb::init<>())
+        .def("__init__",
+                StructureAdapter_constructor<CrystalStructureAdapter>,
+                nb::arg("content"),
                 doc_StructureAdapter___init__fromstring)
-        .def(self == self)
-        .def(self != self)
+        .def(nb::self == nb::self)
+        .def(nb::self != nb::self)
         .def("clone",
                 &CrystalStructureAdapter::clone,
-                &CrystalStructureAdapterWrap::default_clone,
                 doc_CrystalStructureAdapter_clone)
         .def("_customPQConfig",
                 &CrystalStructureAdapter::customPQConfig,
-                &CrystalStructureAdapterWrap::default_customPQConfig,
-                python::arg("pqobj"),
+                nb::arg("pqobj"),
                 doc_StructureAdapter__customPQConfig)
         .def("diff",
                 &CrystalStructureAdapter::diff,
-                &CrystalStructureAdapterWrap::default_diff,
-                python::arg("other"),
+                nb::arg("other"),
                 doc_StructureAdapter_diff)
-        .add_property("symmetryprecision",
+        .def_prop_rw("symmetryprecision",
             crystaladapter_getsymmetryprecision,
             &CrystalStructureAdapter::setSymmetryPrecision,
             doc_CrystalStructureAdapter_symmetryprecision)
@@ -675,22 +762,22 @@ void wrap_AtomicStructureAdapter()
         .def("clearSymOps", &CrystalStructureAdapter::clearSymOps,
                 doc_CrystalStructureAdapter_clearSymOps)
         .def("addSymOp", crystaladapter_addsymop,
-                (bp::arg("R"), bp::arg("t")),
+                nb::arg("R"), nb::arg("t"),
                 doc_CrystalStructureAdapter_addSymOp)
-        .def("getSymOp", crystaladapter_getsymop, bp::arg("index"),
+        .def("getSymOp", crystaladapter_getsymop, nb::arg("index"),
                 doc_CrystalStructureAdapter_getSymOp)
         .def("getEquivalentAtoms",
-                crystaladapter_getequivalentatoms, bp::arg("index"),
+                crystaladapter_getequivalentatoms, nb::arg("index"),
                 doc_CrystalStructureAdapter_getEquivalentAtoms)
         .def("expandLatticeAtom",
                 expandLatticeAtom_aslist<CrystalStructureAdapter, Atom>,
-                bp::arg("atom"),
+                nb::arg("atom"),
                 doc_CrystalStructureAdapter_expandLatticeAtom)
         .def("updateSymmetryPositions",
                 &CrystalStructureAdapter::updateSymmetryPositions,
                 doc_CrystalStructureAdapter_updateSymmetryPositions)
-        .def_pickle(StructureAdapterPickleSuite<CrystalStructureAdapterWrap>())
         ;
+    StructureAdapterPickleSuite<CrystalStructureAdapter>::bind(crystal_class);
 
 }
 

--- a/src/extensions/wrap_AtomicStructureAdapter.cpp
+++ b/src/extensions/wrap_AtomicStructureAdapter.cpp
@@ -362,7 +362,7 @@ class MakeWrapper :
         {
             nb::gil_scoped_acquire gil;
             nb::detail::ticket ticket(nb_trampoline, "diff", false);
-            if (ticket.key.is_valid()) 
+            if (ticket.key.is_valid())
             {
                 nb::object sdobj = nb_trampoline.base().attr(ticket.key)(other);
                 sync_StructureDifference(sdobj);
@@ -426,7 +426,7 @@ class atomadapter_indexing : public nb::def_visitor<atomadapter_indexing>
 
         typedef AtomicStructureAdapter Container;
 
-        
+
         template <typename Class, typename... Extra>
         void execute(Class& cls, const Extra&...)
         {
@@ -465,7 +465,7 @@ class atomadapter_indexing : public nb::def_visitor<atomadapter_indexing>
             // make sure slice is of a correct type and has a copy
             // of any additional structure data.
             StructureAdapterPtr rv = container.clone();
-            AtomicStructureAdapterPtr rva = 
+            AtomicStructureAdapterPtr rva =
                 std::static_pointer_cast<AtomicStructureAdapter>(rv);
             rva->clear();
             // handle index ranges for a valid and empty slice
@@ -494,7 +494,7 @@ class atomadapter_indexing : public nb::def_visitor<atomadapter_indexing>
 
     private:
 
-    
+
         static int normalize_index(const Container& container, int idx)
         {
             ensure_index_bounds(idx, -int(container.size()), container.size());

--- a/src/extensions/wrap_Attributes.cpp
+++ b/src/extensions/wrap_Attributes.cpp
@@ -178,7 +178,11 @@ void wrap_Attributes(nb::module_& m)
 {
     using namespace nswrap_Attributes;
     // ready for class definition
-    nb::class_<Attributes>(m, "Attributes", nb::dynamic_attr(), doc_Attributes)
+    nb::class_<Attributes>(
+            m, "Attributes",
+            nb::dynamic_attr(),
+            nb::is_weak_referenceable(),
+            doc_Attributes)
         .def(nb::init<>())
         .def("_getDoubleAttr", &Attributes::getDoubleAttr,
                 doc_Attributes__getDoubleAttr)

--- a/src/extensions/wrap_Attributes.cpp
+++ b/src/extensions/wrap_Attributes.cpp
@@ -177,7 +177,6 @@ void registerPythonDoubleAttribute(nb::object owner,
 void wrap_Attributes(nb::module_& m)
 {
     using namespace nswrap_Attributes;
-    const nb::object None;
     // ready for class definition
     nb::class_<Attributes>(m, "Attributes", nb::dynamic_attr(), doc_Attributes)
         .def(nb::init<>())

--- a/src/extensions/wrap_Attributes.cpp
+++ b/src/extensions/wrap_Attributes.cpp
@@ -16,7 +16,8 @@
 *
 *****************************************************************************/
 
-#include <boost/python/class.hpp>
+#include <nanobind/nanobind.h>
+#include <nanobind/operators.h>
 
 #include <cassert>
 
@@ -24,11 +25,11 @@
 
 #include "srreal_converters.hpp"
 
+namespace nb = nanobind;
+
 namespace srrealmodule {
 namespace nswrap_Attributes {
 
-using std::string;
-using namespace boost;
 using namespace diffpy::attributes;
 
 // docstrings ----------------------------------------------------------------
@@ -103,8 +104,8 @@ class PythonDoubleAttribute : public BaseDoubleAttribute
     public:
 
         // constructor
-        PythonDoubleAttribute(python::object owner,
-                python::object getter, python::object setter)
+        PythonDoubleAttribute(nb::object owner,
+                nb::object getter, nb::object setter)
         {
             // PythonDoubleAttribute needs to know its Python owner, but it
             // has to use a borrowed reference otherwise the owner would be
@@ -116,28 +117,29 @@ class PythonDoubleAttribute : public BaseDoubleAttribute
         }
 
 
-        double getValue(const Attributes* obj) const
+        double getValue(const Attributes* obj) const override
         {
+            nb::gil_scoped_acquire gil;
             // verify that mowner is indeed the obj wrapper
-            python::object owner(python::borrowed(mowner));
-            assert(obj == python::extract<const Attributes*>(owner));
-            python::object pyrv = mgetter(owner);
-            double rv = python::extract<double>(pyrv);
-            return rv;
+            nb::object owner = nb::borrow<nb::object>(mowner);
+            assert(obj == nb::cast<const Attributes*>(owner));
+            nb::object pyrv = mgetter(owner);
+            return nb::cast<double>(pyrv);
         }
 
 
-        void setValue(Attributes* obj, double value)
+        void setValue(Attributes* obj, double value) override
         {
+            nb::gil_scoped_acquire gil;
             if (this->isreadonly())  throwDoubleAttributeReadOnly();
             // verify that mowner is indeed the obj wrapper
-            python::object owner(python::borrowed(mowner));
-            assert(obj == python::extract<Attributes*>(owner));
+            nb::object owner = nb::borrow<nb::object>(mowner);
+            assert(obj == nb::cast<Attributes*>(owner));
             msetter(owner, value);
         }
 
 
-        bool isreadonly() const
+        bool isreadonly() const override
         {
             return (msetter.is_none());
         }
@@ -146,24 +148,24 @@ class PythonDoubleAttribute : public BaseDoubleAttribute
 
         // data
         PyObject* mowner;
-        python::object mgetter;
-        python::object msetter;
+        nb::object mgetter;
+        nb::object msetter;
 
 };  // class PythonDoubleAttribute
 
 
-void registerPythonDoubleAttribute(python::object owner,
-        const string& name, python::object g, python::object s)
+void registerPythonDoubleAttribute(nb::object owner,
+        const std::string& name, nb::object g, nb::object s)
 {
     // when neither getter no setter are specified,
     // make it use normal python attribute access
     if (g.is_none() && s.is_none())
     {
-        python::object mod = python::import("diffpy.srreal.attributes");
+        nb::object mod = nb::module_::import_("diffpy.srreal.attributes");
         g = mod.attr("_pyattrgetter")(name);
         s = mod.attr("_pyattrsetter")(name);
     }
-    Attributes* cowner = python::extract<Attributes*>(owner);
+    Attributes* cowner = nb::cast<Attributes*>(owner);
     BaseDoubleAttribute* pa = new PythonDoubleAttribute(owner, g, s);
     registerBaseDoubleAttribute(cowner, name, pa);
 }
@@ -172,13 +174,13 @@ void registerPythonDoubleAttribute(python::object owner,
 
 // Wrapper definition --------------------------------------------------------
 
-void wrap_Attributes()
+void wrap_Attributes(nb::module_& m)
 {
     using namespace nswrap_Attributes;
-    using namespace boost::python;
-    const python::object None;
+    const nb::object None;
     // ready for class definition
-    class_<Attributes>("Attributes", doc_Attributes)
+    nb::class_<Attributes>(m, "Attributes", nb::dynamic_attr(), doc_Attributes)
+        .def(nb::init<>())
         .def("_getDoubleAttr", &Attributes::getDoubleAttr,
                 doc_Attributes__getDoubleAttr)
         .def("_setDoubleAttr", &Attributes::setDoubleAttr,
@@ -193,7 +195,9 @@ void wrap_Attributes()
                 doc_Attributes__namesOfWritableDoubleAttributes)
         .def("_registerDoubleAttribute",
                 registerPythonDoubleAttribute,
-                (python::arg("getter")=None, python::arg("setter")=None),
+                nb::arg("name"),
+                nb::arg("getter") = nb::none(),
+                nb::arg("setter") = nb::none(),
                 doc_Attributes__registerDoubleAttribute)
         ;
 }

--- a/src/extensions/wrap_BVParametersTable.cpp
+++ b/src/extensions/wrap_BVParametersTable.cpp
@@ -16,10 +16,8 @@
 *
 *****************************************************************************/
 
-#include <boost/python/class.hpp>
-#include <boost/python/overloads.hpp>
-#include <boost/python/copy_const_reference.hpp>
-#include <boost/python/register_ptr_to_python.hpp>
+#include <nanobind/nanobind.h>
+#include <nanobind/operators.h>
 
 #include <string>
 
@@ -31,10 +29,11 @@
 
 #define BVPARMCIF "bvparm2011.cif"
 
+namespace nb = nanobind;
+
 namespace srrealmodule {
 namespace nswrap_BVParametersTable {
 
-using namespace boost::python;
 using namespace diffpy::srreal;
 
 // docstrings ----------------------------------------------------------------
@@ -218,27 +217,43 @@ Return a set of BVParam objects.\n\
 
 // wrappers ------------------------------------------------------------------
 
-BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(setcustom6, setCustom, 6, 7)
 DECLARE_PYSET_METHOD_WRAPPER(getAll, getAll_asset)
+void setCustom6(BVParametersTable& obj,
+                const std::string& atom0,
+                int valence0,
+                const std::string& atom1,
+                int valence1,
+                double Ro,
+                double B,
+                const std::string& ref_id) {
+    obj.setCustom(atom0, valence0, atom1, valence1, Ro, B, ref_id);
+}
 
-object repr_BVParam(const BVParam& bp)
+nb::object repr_BVParam(const BVParam& bp)
 {
-    if (bp == BVParametersTable::none())  return object("BVParam()");
-    object rv = ("BVParam(%r, %i, %r, %i, Ro=%s, B=%s, ref_id=%r)" %
-        make_tuple(bp.matom0, bp.mvalence0, bp.matom1, bp.mvalence1,
-            bp.mRo, bp.mB, bp.mref_id));
-    return rv;
+    if (bp == BVParametersTable::none())  return nb::str("BVParam()");
+    return nb::str(
+        "BVParam({!r}, {:d}, {!r}, {:d}, Ro={}, B={}, ref_id={!r})"
+    ).attr("format")(
+        bp.matom0,
+        bp.mvalence0,
+        bp.matom1,
+        bp.mvalence1,
+        bp.mRo,
+        bp.mB,
+        bp.mref_id
+    );
 }
 
 
-object singleton_none()
+nb::object singleton_none()
 {
     const char* nameofnone = "__BVParam_singleton_none";
-    object mod = import("diffpy.srreal.srreal_ext");
+    nb::module_ mod = nb::module_::import_("diffpy.srreal.srreal_ext");
     static bool noneassigned = false;
     if (!noneassigned)
     {
-        mod.attr(nameofnone) = object(BVParametersTable::none());
+        mod.attr(nameofnone) = nb::cast(BVParametersTable::none(), nb::rv_policy::copy);
         noneassigned = true;
     }
     return mod.attr(nameofnone);
@@ -248,89 +263,131 @@ object singleton_none()
 
 // Wrapper definition --------------------------------------------------------
 
-void wrap_BVParametersTable()
+void wrap_BVParametersTable(nb::module_& m)
 {
     using namespace nswrap_BVParametersTable;
-    using std::string;
 
-    class_<BVParam>("BVParam", doc_BVParam)
-        .def(init<const string&, int, const string&, int,
-                double, double, string>(doc_BVParam___init__,
-                    (arg("atom0"), arg("valence0"),
-                    arg("atom1"), arg("valence1"), arg("Ro")=0.0, arg("B")=0.0,
-                    arg("ref_id")="")))
+    nb::class_<BVParam> bvparam(m, "BVParam", doc_BVParam);
+    bvparam
+        .def(nb::init<const std::string&, int,
+                      const std::string&, int,
+                      double, double, std::string>(),
+             nb::arg("atom0"),
+             nb::arg("valence0"),
+             nb::arg("atom1"),
+             nb::arg("valence1"),
+             nb::arg("Ro") = 0.0,
+             nb::arg("B") = 0.0,
+             nb::arg("ref_id") = "",
+             doc_BVParam___init__)
         .def("__repr__", repr_BVParam, doc_BVParam___repr__)
-        .def(self == self)
-        .def(self != self)
+        .def(nb::self == nb::self)
+        .def(nb::self != nb::self)
         .def("bondvalence", &BVParam::bondvalence,
-                arg("distance"), doc_BVParam_bondvalence)
+                nb::arg("distance"), doc_BVParam_bondvalence)
         .def("bondvalenceToDistance", &BVParam::bondvalenceToDistance,
-                arg("valence"), doc_BVParam_bondvalenceToDistance)
+                nb::arg("valence"), doc_BVParam_bondvalenceToDistance)
         .def("setFromCifLine", &BVParam::setFromCifLine,
                 doc_BVParam_setFromCifLine)
-        .def_readonly("atom0", &BVParam::matom0, doc_BVParam_atom0)
-        .def_readonly("valence0", &BVParam::mvalence0, doc_BVParam_valence0)
-        .def_readonly("atom1", &BVParam::matom1, doc_BVParam_atom1)
-        .def_readonly("valence1", &BVParam::mvalence1, doc_BVParam_valence1)
-        .def_readwrite("Ro", &BVParam::mRo, doc_BVParam_Ro)
-        .def_readwrite("B", &BVParam::mB, doc_BVParam_B)
-        .def_readwrite("ref_id", &BVParam::mref_id, doc_BVParam_ref_id)
-        .def_pickle(SerializationPickleSuite<BVParam>())
+        .def_ro("atom0", &BVParam::matom0, doc_BVParam_atom0)
+        .def_ro("valence0", &BVParam::mvalence0, doc_BVParam_valence0)
+        .def_ro("atom1", &BVParam::matom1, doc_BVParam_atom1)
+        .def_ro("valence1", &BVParam::mvalence1, doc_BVParam_valence1)
+        .def_rw("Ro", &BVParam::mRo, doc_BVParam_Ro)
+        .def_rw("B", &BVParam::mB, doc_BVParam_B)
+        .def_rw("ref_id", &BVParam::mref_id, doc_BVParam_ref_id)
         ;
+        SerializationPickleSuite<BVParam, DICT_IGNORE>::bind(bvparam);
 
-    typedef const BVParam&(BVParametersTable::*bptb_bvparam_1)(
-            const BVParam&) const;
-    typedef const BVParam&(BVParametersTable::*bptb_bvparam_2)(
-            const string&, const string&) const;
-    typedef const BVParam&(BVParametersTable::*bptb_bvparam_4)(
-            const string&, int, const string&, int) const;
-    typedef void(BVParametersTable::*bptb_void_1)(
-            const BVParam&);
-    typedef void(BVParametersTable::*bptb_void_4)(
-            const string&, int, const string&, int);
-
-    class_<BVParametersTable>("BVParametersTable", doc_BVParametersTable)
-        .def("none", singleton_none, doc_BVParametersTable_none)
-        .staticmethod("none")
+    nb::class_<BVParametersTable>
+        bvtable(m, "BVParametersTable", doc_BVParametersTable);
+    bvtable
+        .def(nb::init<>())
+        .def_static("none", singleton_none, doc_BVParametersTable_none)
         .def("getAtomValence", &BVParametersTable::getAtomValence,
-                arg("smbl"),
+                nb::arg("smbl"),
                 doc_BVParametersTable_getAtomValence)
         .def("setAtomValence", &BVParametersTable::setAtomValence,
-                (arg("smbl"), arg("value")),
+                nb::arg("smbl"), nb::arg("value"),
                 doc_BVParametersTable_setAtomValence)
         .def("resetAtomValences", &BVParametersTable::resetAtomValences,
                 doc_BVParametersTable_resetAtomValences)
-        .def("lookup", bptb_bvparam_1(&BVParametersTable::lookup),
-                arg("bvparam"), doc_BVParametersTable_lookup1,
-                return_value_policy<copy_const_reference>())
-        .def("lookup", bptb_bvparam_2(&BVParametersTable::lookup),
-                (arg("smbl0"), arg("smbl1")),
-                doc_BVParametersTable_lookup2,
-                return_value_policy<copy_const_reference>())
-        .def("lookup", bptb_bvparam_4(&BVParametersTable::lookup),
-                (arg("atom0"), arg("valence0"), arg("atom1"), arg("valence1")),
-                doc_BVParametersTable_lookup4,
-                return_value_policy<copy_const_reference>())
-        .def("setCustom", bptb_void_1(&BVParametersTable::setCustom),
-                arg("bvparm"), doc_BVParametersTable_setCustom1)
-        .def("setCustom", (void(BVParametersTable::*)(const string&, int,
-                    const string&, int, double, double, string)) NULL,
-                setcustom6((arg("atom0"), arg("valence0"), arg("atom1"), arg("valence1"),
-                     arg("Ro"), arg("B"), arg("ref_id")=""),
-                    doc_BVParametersTable_setCustom6))
-        .def("resetCustom", bptb_void_1(&BVParametersTable::resetCustom),
-                doc_BVParametersTable_resetCustom1)
-        .def("resetCustom", bptb_void_4(&BVParametersTable::resetCustom),
-                (arg("atom0"), arg("valence0"), arg("atom1"), arg("valence1")),
-                doc_BVParametersTable_resetCustom4)
+        .def("lookup",
+             [](const BVParametersTable &obj,
+                const BVParam &bvparam) -> BVParam {
+                 return obj.lookup(bvparam);
+             },
+             nb::arg("bvparam"),
+             doc_BVParametersTable_lookup1)
+
+        .def("lookup",
+             [](const BVParametersTable &obj,
+                const std::string &smbl0,
+                const std::string &smbl1) -> BVParam {
+                 return obj.lookup(smbl0, smbl1);
+             },
+             nb::arg("smbl0"),
+             nb::arg("smbl1"),
+             doc_BVParametersTable_lookup2)
+
+        .def("lookup",
+             [](const BVParametersTable &obj,
+                const std::string &atom0,
+                int valence0,
+                const std::string &atom1,
+                int valence1) -> BVParam {
+                 return obj.lookup(atom0, valence0, atom1, valence1);
+             },
+             nb::arg("atom0"),
+             nb::arg("valence0"),
+             nb::arg("atom1"),
+             nb::arg("valence1"),
+             doc_BVParametersTable_lookup4)
+
+        .def("setCustom",
+             [](BVParametersTable &obj, const BVParam &bvparam) {
+                 obj.setCustom(bvparam);
+             },
+             nb::arg("bvparam"),
+             doc_BVParametersTable_setCustom1)
+
+        .def("setCustom",
+             &setCustom6,
+             nb::arg("atom0"),
+             nb::arg("valence0"),
+             nb::arg("atom1"),
+             nb::arg("valence1"),
+             nb::arg("Ro"),
+             nb::arg("B"),
+             nb::arg("ref_id") = "",
+             doc_BVParametersTable_setCustom6)
+        .def("resetCustom",
+             [](BVParametersTable &obj, const BVParam &bvparam) {
+                 obj.resetCustom(bvparam);
+             },
+             nb::arg("bvparam"),
+             doc_BVParametersTable_resetCustom1)
+
+        .def("resetCustom",
+             [](BVParametersTable &obj,
+                const std::string &atom0,
+                int valence0,
+                const std::string &atom1,
+                int valence1) {
+                 obj.resetCustom(atom0, valence0, atom1, valence1);
+             },
+             nb::arg("atom0"),
+             nb::arg("valence0"),
+             nb::arg("atom1"),
+             nb::arg("valence1"),
+             doc_BVParametersTable_resetCustom4)
         .def("resetAll", &BVParametersTable::resetAll,
                 doc_BVParametersTable_resetAll)
         .def("getAll", getAll_asset<BVParametersTable>,
                 doc_BVParametersTable_getAll)
-        .def_pickle(SerializationPickleSuite<BVParametersTable>())
         ;
-
-    register_ptr_to_python<BVParametersTablePtr>();
+        SerializationPickleSuite<BVParametersTable, DICT_IGNORE>::bind(bvtable);
+        
 }
 
 }   // namespace srrealmodule

--- a/src/extensions/wrap_BVParametersTable.cpp
+++ b/src/extensions/wrap_BVParametersTable.cpp
@@ -298,7 +298,7 @@ void wrap_BVParametersTable(nb::module_& m)
         .def_rw("B", &BVParam::mB, doc_BVParam_B)
         .def_rw("ref_id", &BVParam::mref_id, doc_BVParam_ref_id)
         ;
-        SerializationPickleSuite<BVParam, DICT_IGNORE>::bind(bvparam);
+        SerializationPickleSuite<BVParam, DICT_GUARD>::bind(bvparam);
 
     nb::class_<BVParametersTable>
         bvtable(m, "BVParametersTable", doc_BVParametersTable);
@@ -387,7 +387,7 @@ void wrap_BVParametersTable(nb::module_& m)
         .def("getAll", getAll_asset<BVParametersTable>,
                 doc_BVParametersTable_getAll)
         ;
-        SerializationPickleSuite<BVParametersTable, DICT_IGNORE>::bind(bvtable);
+        SerializationPickleSuite<BVParametersTable, DICT_GUARD>::bind(bvtable);
         
 }
 

--- a/src/extensions/wrap_BVParametersTable.cpp
+++ b/src/extensions/wrap_BVParametersTable.cpp
@@ -269,6 +269,7 @@ void wrap_BVParametersTable(nb::module_& m)
 
     nb::class_<BVParam> bvparam(m, "BVParam", doc_BVParam);
     bvparam
+        .def(nb::init<>())
         .def(nb::init<const std::string&, int,
                       const std::string&, int,
                       double, double, std::string>(),

--- a/src/extensions/wrap_BVParametersTable.cpp
+++ b/src/extensions/wrap_BVParametersTable.cpp
@@ -388,7 +388,7 @@ void wrap_BVParametersTable(nb::module_& m)
                 doc_BVParametersTable_getAll)
         ;
         SerializationPickleSuite<BVParametersTable, DICT_GUARD>::bind(bvtable);
-        
+
 }
 
 }   // namespace srrealmodule

--- a/src/extensions/wrap_BVSCalculator.cpp
+++ b/src/extensions/wrap_BVSCalculator.cpp
@@ -89,6 +89,7 @@ void wrap_BVSCalculator(nb::module_& m)
     nb::class_<BVSCalculator, PairQuantity> bvscalculator(m, "BVSCalculator",
             doc_BVSCalculator);
     bvscalculator
+        .def(nb::init<>())
         .def_prop_ro("value", value_asarray<BVSCalculator>,
                 doc_BVSCalculator_value)
         .def_prop_ro("valences", valences_asarray<BVSCalculator>,

--- a/src/extensions/wrap_BVSCalculator.cpp
+++ b/src/extensions/wrap_BVSCalculator.cpp
@@ -16,17 +16,18 @@
 *
 *****************************************************************************/
 
-#include <boost/python/class.hpp>
+#include <nanobind/nanobind.h>
 
 #include <diffpy/srreal/BVSCalculator.hpp>
 
 #include "srreal_converters.hpp"
 #include "srreal_pickling.hpp"
 
+namespace nb = nanobind;
+
 namespace srrealmodule {
 namespace nswrap_BVSCalculator {
 
-using namespace boost::python;
 using namespace diffpy::srreal;
 
 // docstrings ----------------------------------------------------------------
@@ -81,26 +82,27 @@ void setbvparamtable(BVSCalculator& obj, BVParametersTablePtr bptb)
 
 // Wrapper definition --------------------------------------------------------
 
-void wrap_BVSCalculator()
+void wrap_BVSCalculator(nb::module_& m)
 {
     using namespace nswrap_BVSCalculator;
 
-    class_<BVSCalculator, bases<PairQuantity> >("BVSCalculator",
-            doc_BVSCalculator)
-        .add_property("value", value_asarray<BVSCalculator>,
+    nb::class_<BVSCalculator, PairQuantity> bvscalculator(m, "BVSCalculator",
+            doc_BVSCalculator);
+    bvscalculator
+        .def_prop_ro("value", value_asarray<BVSCalculator>,
                 doc_BVSCalculator_value)
-        .add_property("valences", valences_asarray<BVSCalculator>,
+        .def_prop_ro("valences", valences_asarray<BVSCalculator>,
                 doc_BVSCalculator_valences)
-        .add_property("bvdiff", bvdiff_asarray<BVSCalculator>,
+        .def_prop_ro("bvdiff", bvdiff_asarray<BVSCalculator>,
                 doc_BVSCalculator_bvdiff)
-        .add_property("bvmsdiff", &BVSCalculator::bvmsdiff,
+        .def_prop_ro("bvmsdiff", &BVSCalculator::bvmsdiff,
                 doc_BVSCalculator_bvmsdiff)
-        .add_property("bvrmsdiff", &BVSCalculator::bvrmsdiff,
+        .def_prop_ro("bvrmsdiff", &BVSCalculator::bvrmsdiff,
                 doc_BVSCalculator_bvrmsdiff)
-        .add_property("bvparamtable", getbvparamtable, setbvparamtable,
+        .def_prop_rw("bvparamtable", getbvparamtable, setbvparamtable,
                 doc_BVSCalculator_bvparamtable)
-        .def_pickle(PairQuantityPickleSuite<BVSCalculator>())
         ;
+        PairQuantityPickleSuite<BVSCalculator>::bind(bvscalculator);
 
 }
 

--- a/src/extensions/wrap_BaseBondGenerator.cpp
+++ b/src/extensions/wrap_BaseBondGenerator.cpp
@@ -18,10 +18,7 @@
 *
 *****************************************************************************/
 
-#include <boost/python/class.hpp>
-#include <boost/python/args.hpp>
-#include <boost/python/copy_const_reference.hpp>
-#include <boost/python/register_ptr_to_python.hpp>
+#include <nanobind/nanobind.h>
 
 #include <string>
 
@@ -29,6 +26,8 @@
 #include <diffpy/srreal/StructureAdapter.hpp>
 
 #include "srreal_converters.hpp"
+
+namespace nb = nanobind;
 
 namespace srrealmodule {
 namespace nswrap_BaseBondGenerator {
@@ -152,14 +151,13 @@ DECLARE_PYARRAY_METHOD_WRAPPER(Ucartesian1, Ucartesian1_asarray)
 
 // Wrapper definition --------------------------------------------------------
 
-void wrap_BaseBondGenerator()
+void wrap_BaseBondGenerator(nb::module_& m)
 {
-    using namespace boost::python;
     using namespace diffpy::srreal;
     using namespace nswrap_BaseBondGenerator;
 
-    class_<BaseBondGenerator>("BaseBondGenerator", doc_BaseBondGenerator,
-            init<StructureAdapterPtr>())
+    nb::class_<BaseBondGenerator>(m, "BaseBondGenerator", doc_BaseBondGenerator)
+        .def(nb::init<StructureAdapterPtr>())
         .def("rewind", &BaseBondGenerator::rewind,
                 doc_BaseBondGenerator_rewind)
         .def("finished", &BaseBondGenerator::finished,
@@ -167,19 +165,19 @@ void wrap_BaseBondGenerator()
         .def("next", &BaseBondGenerator::next,
                 doc_BaseBondGenerator_next)
         .def("selectAnchorSite", &BaseBondGenerator::selectAnchorSite,
-                arg("anchor"), doc_BaseBondGenerator_selectAnchorSite)
+                nb::arg("anchor"), doc_BaseBondGenerator_selectAnchorSite)
         .def("selectSiteRange", &BaseBondGenerator::selectSiteRange,
-                (arg("first"), arg("last")),
+                nb::arg("first"), nb::arg("last"),
                 doc_BaseBondGenerator_selectSiteRange)
         .def("setRmin", &BaseBondGenerator::setRmin,
-                arg("rmin"), doc_BaseBondGenerator_setRmin)
+                nb::arg("rmin"), doc_BaseBondGenerator_setRmin)
         .def("setRmax", &BaseBondGenerator::setRmax,
-                arg("rmax"), doc_BaseBondGenerator_setRmax)
+                nb::arg("rmax"), doc_BaseBondGenerator_setRmax)
         .def("getRmin", &BaseBondGenerator::getRmin,
-                return_value_policy<copy_const_reference>(),
+                nb::rv_policy::copy,
                 doc_BaseBondGenerator_getRmin)
         .def("getRmax", &BaseBondGenerator::getRmax,
-                return_value_policy<copy_const_reference>(),
+                nb::rv_policy::copy,
                 doc_BaseBondGenerator_getRmax)
         .def("site0", &BaseBondGenerator::site0,
                 doc_BaseBondGenerator_site0)
@@ -192,7 +190,7 @@ void wrap_BaseBondGenerator()
         .def("r1", r1_asarray<BaseBondGenerator>,
                 doc_BaseBondGenerator_r1)
         .def("distance", &BaseBondGenerator::distance,
-                return_value_policy<copy_const_reference>(),
+                nb::rv_policy::copy,
                 doc_BaseBondGenerator_distance)
         .def("r01", r01_asarray<BaseBondGenerator>,
                 doc_BaseBondGenerator_r01)
@@ -203,8 +201,6 @@ void wrap_BaseBondGenerator()
         .def("msd", &BaseBondGenerator::msd,
                 doc_BaseBondGenerator_msd)
         ;
-
-    register_ptr_to_python<BaseBondGeneratorPtr>();
 }
 
 }   // namespace srrealmodule

--- a/src/extensions/wrap_BondCalculator.cpp
+++ b/src/extensions/wrap_BondCalculator.cpp
@@ -16,18 +16,18 @@
 *
 *****************************************************************************/
 
-#include <boost/python/class.hpp>
+#include <nanobind/nanobind.h>
 
 #include <diffpy/srreal/BondCalculator.hpp>
 
 #include "srreal_converters.hpp"
 #include "srreal_pickling.hpp"
 
+namespace nb = nanobind;
+
 namespace srrealmodule {
 namespace nswrap_BondCalculator {
 
-namespace bp = boost::python;
-using namespace boost::python;
 using namespace diffpy::srreal;
 
 // docstrings ----------------------------------------------------------------
@@ -82,18 +82,16 @@ exclusive cone filter in a new direction.\n\
 
 
 void filter_cone(BondCalculator& obj,
-        object cartesiandir, double degrees)
+        nb::object cartesiandir, double degrees)
 {
     if (len(cartesiandir) != 3)
     {
-        const char* emsg = "cartesiandir must be a 3-element array.";
-        PyErr_SetString(PyExc_ValueError, emsg);
-        bp::throw_error_already_set();
+        throw nb::value_error("cartesiandir must be a 3-element array.");
     }
     R3::Vector cdir;
-    cdir[0] = extract<double>(cartesiandir[0]);
-    cdir[1] = extract<double>(cartesiandir[1]);
-    cdir[2] = extract<double>(cartesiandir[2]);
+    cdir[0] = nb::cast<double>(cartesiandir[0]);
+    cdir[1] = nb::cast<double>(cartesiandir[1]);
+    cdir[2] = nb::cast<double>(cartesiandir[2]);
     obj.filterCone(cdir, degrees);
 }
 
@@ -101,38 +99,39 @@ void filter_cone(BondCalculator& obj,
 
 // Wrapper definition --------------------------------------------------------
 
-void wrap_BondCalculator()
+void wrap_BondCalculator(nb::module_& m)
 {
     using namespace nswrap_BondCalculator;
 
-    class_<BondCalculator, bases<PairQuantity>
-        >("BondCalculator", doc_BondCalculator)
-        .add_property("distances",
+    nb::class_<BondCalculator, PairQuantity>
+        bondcalculator(m, "BondCalculator", doc_BondCalculator);
+    bondcalculator
+        .def(nb::init<>())
+        .def_prop_ro("distances",
                 distances_asarray<BondCalculator>,
                 doc_BondCalculator_distances)
-        .add_property("directions",
+        .def_prop_ro("directions",
                 directions_asarray<BondCalculator>,
                 doc_BondCalculator_directions)
-        .add_property("sites0",
+        .def_prop_ro("sites0",
                 sites0_asarray<BondCalculator>,
                 doc_BondCalculator_sites0)
-        .add_property("sites1",
+        .def_prop_ro("sites1",
                 sites1_asarray<BondCalculator>,
                 doc_BondCalculator_sites1)
-        .add_property("types0",
+        .def_prop_ro("types0",
                 types0_aschararray<BondCalculator>,
                 doc_BondCalculator_types0)
-        .add_property("types1",
+        .def_prop_ro("types1",
                 types1_aschararray<BondCalculator>,
                 doc_BondCalculator_types1)
         .def("filterCone", filter_cone,
-                (bp::arg("cartesiandir"), bp::arg("degrees")),
+                nb::arg("cartesiandir"), nb::arg("degrees"),
                 doc_BondCalculator_filterCone)
         .def("filterOff", &BondCalculator::filterOff,
                 doc_BondCalculator_filterOff)
-        .def_pickle(PairQuantityPickleSuite<BondCalculator>())
         ;
-
+        PairQuantityPickleSuite<BondCalculator>::bind(bondcalculator);
 }
 
 }   // namespace srrealmodule

--- a/src/extensions/wrap_EventTicker.cpp
+++ b/src/extensions/wrap_EventTicker.cpp
@@ -16,11 +16,14 @@
 *
 *****************************************************************************/
 
-#include <boost/python/class.hpp>
+#include <nanobind/nanobind.h>
+#include <nanobind/operators.h>
 
 #include <diffpy/EventTicker.hpp>
 
 #include "srreal_pickling.hpp"
+
+namespace nb = nanobind;
 
 namespace srrealmodule {
 namespace nswrap_EventTicker {
@@ -66,47 +69,47 @@ and the first one is zero unless there was an integer overflow.\n\
 
 // getter for the _value property
 
-python::tuple gettickervalue(const EventTicker& tc)
+nb::tuple gettickervalue(const EventTicker& tc)
 {
     EventTicker::value_type v = tc.value();
-    return python::make_tuple(v.first, v.second);
+    return nb::make_tuple(v.first, v.second);
 }
 
 // representation of EventTicker objects
 
-python::object repr_EventTicker(const EventTicker& tc)
+nb::object repr_EventTicker(const EventTicker& tc)
 {
-    python::object rv = ("EventTicker(%i, %i)" % gettickervalue(tc));
-    return rv;
+    auto v = tc.value();
+    return nb::str("EventTicker({}, {})").attr("format")(v.first, v.second);
 }
 
 }   // namespace nswrap_EventTicker
 
 // Wrapper definition --------------------------------------------------------
 
-void wrap_EventTicker()
+void wrap_EventTicker(nb::module_& m)
 {
     using namespace nswrap_EventTicker;
-    using namespace boost::python;
 
-    class_<EventTicker>("EventTicker", doc_EventTicker)
-        .def(init<const EventTicker&>(doc_EventTicker_cp))
+    nb::class_<EventTicker> eventticker(m, "EventTicker", doc_EventTicker);
+    eventticker
+        .def(nb::init<const EventTicker&>(), doc_EventTicker_cp)
         .def("__repr__", repr_EventTicker, doc_EventTicker___repr__)
-        .def(self < self)
-        .def(self <= self)
-        .def(self > self)
-        .def(self >= self)
-        .def(self == self)
-        .def(self != self)
+        .def(nb::self < nb::self)
+        .def(nb::self <= nb::self)
+        .def(nb::self > nb::self)
+        .def(nb::self >= nb::self)
+        .def(nb::self == nb::self)
+        .def(nb::self != nb::self)
         .def("click", &EventTicker::click,
                 doc_EventTicker_click)
         .def("updateFrom", &EventTicker::updateFrom,
-                python::arg("other"),
+                nb::arg("other"),
                 doc_EventTicker_updateFrom)
-        .add_property("_value", gettickervalue,
+        .def_prop_ro("_value", gettickervalue,
                 doc_EventTicker__value)
-        .def_pickle(SerializationPickleSuite<EventTicker,DICT_IGNORE>())
         ;
+        SerializationPickleSuite<EventTicker>::bind(eventticker);
 
 }
 

--- a/src/extensions/wrap_EventTicker.cpp
+++ b/src/extensions/wrap_EventTicker.cpp
@@ -93,6 +93,7 @@ void wrap_EventTicker(nb::module_& m)
 
     nb::class_<EventTicker> eventticker(m, "EventTicker", doc_EventTicker);
     eventticker
+        .def(nb::init<>())
         .def(nb::init<const EventTicker&>(), doc_EventTicker_cp)
         .def("__repr__", repr_EventTicker, doc_EventTicker___repr__)
         .def(nb::self < nb::self)

--- a/src/extensions/wrap_ObjCrystAdapters.cpp
+++ b/src/extensions/wrap_ObjCrystAdapters.cpp
@@ -17,7 +17,7 @@
 *
 *****************************************************************************/
 
-#include <boost/python/def.hpp>
+#include <nanobind/nanobind.h>
 
 #include <cstdlib>
 
@@ -27,6 +27,8 @@
 #ifdef DIFFPY_HAS_OBJCRYST
 #include <diffpy/srreal/ObjCrystStructureAdapter.hpp>
 #endif
+
+namespace nb = nanobind;
 
 namespace srrealmodule {
 namespace nswrap_ObjCrystAdapters {
@@ -81,10 +83,7 @@ StructureAdapterPtr convertObjCrystCrystal(const Crystal& mol)
 
 StructureAdapterPtr convertObjCrystMolecule(python::object mol)
 {
-    std::string emsg = "ObjCryst support not available.";
-    PyErr_SetString(PyExc_TypeError, emsg.c_str());
-    boost::python::throw_error_already_set();
-    abort();
+    throw nb::type_error("ObjCryst support not available.");
 }
 
 StructureAdapterPtr convertObjCrystCrystal(python::object cryst)
@@ -99,14 +98,13 @@ StructureAdapterPtr convertObjCrystCrystal(python::object cryst)
 
 // Wrapper definitions -------------------------------------------------------
 
-void wrap_ObjCrystAdapters()
+void wrap_ObjCrystAdapters(nb::module_& m)
 {
     using namespace nswrap_ObjCrystAdapters;
-    using namespace boost::python;
 
-    def("convertObjCrystMolecule",
+    m.def("convertObjCrystMolecule",
             convertObjCrystMolecule, doc_convertObjCrystMolecule);
-    def("convertObjCrystCrystal",
+    m.def("convertObjCrystCrystal",
             convertObjCrystCrystal, doc_convertObjCrystCrystal);
 
 }

--- a/src/extensions/wrap_ObjCrystAdapters.cpp
+++ b/src/extensions/wrap_ObjCrystAdapters.cpp
@@ -33,7 +33,6 @@ namespace nb = nanobind;
 namespace srrealmodule {
 namespace nswrap_ObjCrystAdapters {
 
-using namespace boost;
 using namespace diffpy::srreal;
 
 // docstrings ----------------------------------------------------------------
@@ -81,12 +80,12 @@ StructureAdapterPtr convertObjCrystCrystal(const Crystal& mol)
 
 #else
 
-StructureAdapterPtr convertObjCrystMolecule(python::object mol)
+StructureAdapterPtr convertObjCrystMolecule(nb::object)
 {
     throw nb::type_error("ObjCryst support not available.");
 }
 
-StructureAdapterPtr convertObjCrystCrystal(python::object cryst)
+StructureAdapterPtr convertObjCrystCrystal(nb::object cryst)
 {
     // raise the same exception as for the Molecule
     return convertObjCrystMolecule(cryst);

--- a/src/extensions/wrap_OverlapCalculator.cpp
+++ b/src/extensions/wrap_OverlapCalculator.cpp
@@ -234,6 +234,7 @@ void wrap_OverlapCalculator(nb::module_& m)
     nb::class_<OverlapCalculator, PairQuantity> overlapcalculator(m, "OverlapCalculator",
             doc_OverlapCalculator);
     overlapcalculator
+        .def(nb::init<>())
         .def_prop_ro("overlaps",
                 overlaps_asarray<OverlapCalculator>,
                 doc_OverlapCalculator_overlaps)

--- a/src/extensions/wrap_OverlapCalculator.cpp
+++ b/src/extensions/wrap_OverlapCalculator.cpp
@@ -18,6 +18,7 @@
 
 #include <nanobind/nanobind.h>
 
+#include <diffpy/srreal/ConstantRadiiTable.hpp>
 #include <diffpy/srreal/OverlapCalculator.hpp>
 
 #include "srreal_converters.hpp"
@@ -196,18 +197,30 @@ class OverlapCalculatorPickleSuite :
             cls
                 .def("__getstate__", getstate)
                 .def("__setstate__", setstate)
+                .def("__reduce__", reduce)
                 ;
+            cls.attr("__getstate_manages_dict__") = nb::none();
         }
 
 
         static nb::tuple getstate(nb::object obj)
         {
-            nb::object tb = obj.attr("atomradiitable");
-            nb::tuple rv = nb::make_tuple(
-                    Super::getstate(obj),
-                    resolve_state_object<AtomRadiiTable>(tb)
-                    );
-            return rv;
+            OverlapCalculator& calc = nb::cast<OverlapCalculator&>(obj);
+            ScopedSharedPtrReplacement<AtomRadiiTable> tb(
+                calc.getAtomRadiiTable(), AtomRadiiTablePtr(new ConstantRadiiTable));
+            try
+            {
+                nb::tuple rv = nb::make_tuple(
+                        Super::getstate(obj),
+                        tb.state_object()
+                        );
+                return rv;
+            }
+            catch (...)
+            {
+                tb.restore();
+                throw;
+            }
         }
 
 
@@ -218,8 +231,14 @@ class OverlapCalculatorPickleSuite :
             // restore the state using boost serialization
             nb::tuple state0(state[0]);
             Super::setstate(obj, state0);
-            // atomradiitable is present only when restoring Python class
-            assign_state_object(obj.attr("atomradiitable"), state[1]);
+            // restore component that was kept out of Boost serialization
+            OverlapCalculator& calc = nb::cast<OverlapCalculator&>(obj);
+            assign_pointer_state(calc.getAtomRadiiTable(), state[1]);
+        }
+
+        static nb::tuple reduce(nb::object obj)
+        {
+            return Super::reduce(obj);
         }
 };
 

--- a/src/extensions/wrap_OverlapCalculator.cpp
+++ b/src/extensions/wrap_OverlapCalculator.cpp
@@ -16,17 +16,18 @@
 *
 *****************************************************************************/
 
-#include <boost/python/class.hpp>
+#include <nanobind/nanobind.h>
 
 #include <diffpy/srreal/OverlapCalculator.hpp>
 
 #include "srreal_converters.hpp"
 #include "srreal_pickling.hpp"
 
+namespace nb = nanobind;
+
 namespace srrealmodule {
 namespace nswrap_OverlapCalculator {
 
-using namespace boost::python;
 using namespace diffpy::srreal;
 
 // docstrings ----------------------------------------------------------------
@@ -156,7 +157,7 @@ AtomRadiiTablePtr getatomradiitable(OverlapCalculator& obj)
 DECLARE_BYTYPE_SETTER_WRAPPER(setAtomRadiiTable, setatomradiitable)
 
 
-double flip_diff_total(const OverlapCalculator& obj, object i, object j)
+double flip_diff_total(const OverlapCalculator& obj, nb::object i, nb::object j)
 {
     int i1 = extractint(i);
     int j1 = extractint(j);
@@ -164,7 +165,7 @@ double flip_diff_total(const OverlapCalculator& obj, object i, object j)
 }
 
 
-double flip_diff_mean(const OverlapCalculator& obj, object i, object j)
+double flip_diff_mean(const OverlapCalculator& obj, nb::object i, nb::object j)
 {
     int i1 = extractint(i);
     int j1 = extractint(j);
@@ -172,10 +173,10 @@ double flip_diff_mean(const OverlapCalculator& obj, object i, object j)
 }
 
 
-object get_neighbor_sites(const OverlapCalculator& obj, object i)
+nb::object get_neighbor_sites(const OverlapCalculator& obj, nb::object i)
 {
     int i1 = extractint(i);
-    object rv = convertToPythonSet(obj.getNeighborSites(i1));
+    nb::object rv = convertToPythonSet(obj.getNeighborSites(i1));
     return rv;
 }
 
@@ -189,11 +190,20 @@ class OverlapCalculatorPickleSuite :
 
     public:
 
-        static boost::python::tuple getstate(boost::python::object obj)
+        template <typename C>
+        static void bind(C& cls)
         {
-            namespace bp = boost::python;
-            bp::object tb = obj.attr("atomradiitable");
-            bp::tuple rv = bp::make_tuple(
+            cls
+                .def("__getstate__", getstate)
+                .def("__setstate__", setstate)
+                ;
+        }
+
+
+        static nb::tuple getstate(nb::object obj)
+        {
+            nb::object tb = obj.attr("atomradiitable");
+            nb::tuple rv = nb::make_tuple(
                     Super::getstate(obj),
                     resolve_state_object<AtomRadiiTable>(tb)
                     );
@@ -202,13 +212,12 @@ class OverlapCalculatorPickleSuite :
 
 
         static void setstate(
-                boost::python::object obj, boost::python::tuple state)
+                nb::object obj, nb::tuple state)
         {
-            namespace bp = boost::python;
             ensure_tuple_length(state, 2);
             // restore the state using boost serialization
-            bp::tuple st0 = bp::extract<bp::tuple>(state[0]);
-            Super::setstate(obj, st0);
+            nb::tuple state0(state[0]);
+            Super::setstate(obj, state0);
             // atomradiitable is present only when restoring Python class
             assign_state_object(obj.attr("atomradiitable"), state[1]);
         }
@@ -218,73 +227,74 @@ class OverlapCalculatorPickleSuite :
 
 // Wrapper definition --------------------------------------------------------
 
-void wrap_OverlapCalculator()
+void wrap_OverlapCalculator(nb::module_& m)
 {
     using namespace nswrap_OverlapCalculator;
 
-    class_<OverlapCalculator, bases<PairQuantity> >("OverlapCalculator",
-            doc_OverlapCalculator)
-        .add_property("overlaps",
+    nb::class_<OverlapCalculator, PairQuantity> overlapcalculator(m, "OverlapCalculator",
+            doc_OverlapCalculator);
+    overlapcalculator
+        .def_prop_ro("overlaps",
                 overlaps_asarray<OverlapCalculator>,
                 doc_OverlapCalculator_overlaps)
-        .add_property("distances",
+        .def_prop_ro("distances",
                 distances_asarray<OverlapCalculator>,
                 doc_OverlapCalculator_distances)
-        .add_property("directions",
+        .def_prop_ro("directions",
                 directions_asarray<OverlapCalculator>,
                 doc_OverlapCalculator_directions)
-        .add_property("sites0",
+        .def_prop_ro("sites0",
                 sites0_asarray<OverlapCalculator>,
                 doc_OverlapCalculator_sites0)
-        .add_property("sites1",
+        .def_prop_ro("sites1",
                 sites1_asarray<OverlapCalculator>,
                 doc_OverlapCalculator_sites1)
-        .add_property("types0",
+        .def_prop_ro("types0",
                 types0_aschararray<OverlapCalculator>,
                 doc_OverlapCalculator_types0)
-        .add_property("types1",
+        .def_prop_ro("types1",
                 types1_aschararray<OverlapCalculator>,
                 doc_OverlapCalculator_types1)
-        .add_property("sitesquareoverlaps",
+        .def_prop_ro("sitesquareoverlaps",
                 siteSquareOverlaps_asarray<OverlapCalculator>,
                 doc_OverlapCalculator_sitesquareoverlaps)
-        .add_property("totalsquareoverlap",
+        .def_prop_ro("totalsquareoverlap",
                 &OverlapCalculator::totalSquareOverlap,
                 doc_OverlapCalculator_totalsquareoverlap)
-        .add_property("meansquareoverlap",
+        .def_prop_ro("meansquareoverlap",
                 &OverlapCalculator::meanSquareOverlap,
                 doc_OverlapCalculator_meansquareoverlap)
         .def("flipDiffTotal",
                 flip_diff_total,
-                (arg("i"), arg("j")),
+                nb::arg("i"), nb::arg("j"),
                 doc_OverlapCalculator_flipDiffTotal)
         .def("flipDiffMean",
                 flip_diff_mean,
                 doc_OverlapCalculator_flipDiffMean)
-        .add_property("gradients",
+        .def_prop_ro("gradients",
                 gradients_asarray<OverlapCalculator>,
                 doc_OverlapCalculator_gradients)
         .def("getNeighborSites",
                 get_neighbor_sites,
-                arg("i"),
+                nb::arg("i"),
                 doc_OverlapCalculator_getNeighborSites)
-        .add_property("coordinations",
+        .def_prop_ro("coordinations",
                 coordinations_asarray<OverlapCalculator>,
                 doc_OverlapCalculator_coordinations)
         .def("coordinationByTypes",
                 coordinationByTypes_asdict<OverlapCalculator,int>,
-                arg("i"),
+                nb::arg("i"),
                 doc_OverlapCalculator_coordinationByTypes)
-        .add_property("neighborhoods",
+        .def_prop_ro("neighborhoods",
                 neighborhoods_aslistset<OverlapCalculator>,
                 doc_OverlapCalculator_neighborhoods)
-        .add_property("atomradiitable",
+        .def_prop_rw("atomradiitable",
                 getatomradiitable,
                 setatomradiitable<OverlapCalculator,AtomRadiiTable>,
                 doc_OverlapCalculator_atomradiitable)
-        .def_pickle(OverlapCalculatorPickleSuite())
         ;
-
+        OverlapCalculatorPickleSuite::bind(overlapcalculator);
+        
 }
 
 }   // namespace srrealmodule

--- a/src/extensions/wrap_OverlapCalculator.cpp
+++ b/src/extensions/wrap_OverlapCalculator.cpp
@@ -314,7 +314,7 @@ void wrap_OverlapCalculator(nb::module_& m)
                 doc_OverlapCalculator_atomradiitable)
         ;
         OverlapCalculatorPickleSuite::bind(overlapcalculator);
-        
+
 }
 
 }   // namespace srrealmodule

--- a/src/extensions/wrap_PDFBaseline.cpp
+++ b/src/extensions/wrap_PDFBaseline.cpp
@@ -70,7 +70,8 @@ PDF baseline function equal to (slope * r).\n\
 // Helper class allows overload of the PDFBaseline methods from Python.
 
 class PDFBaselineWrap :
-    public PDFBaseline
+    public PDFBaseline,
+    public PythonTrampolineTag
 {
     public:
 
@@ -178,7 +179,10 @@ void wrap_PDFBaseline(nb::module_& m)
         .def("__call__", &PDFBaseline::operator(),
                 nb::arg("r"), doc_PDFBaseline___call__)
         ;
-        SerializationPickleSuite<PDFBaseline, DICT_PICKLE>::bind(pdfbaseline);
+        SerializationPickleSuite<
+            PDFBaseline,
+            DICT_PICKLE,
+            PDFBaselineWrap>::bind(pdfbaseline);
 
     nb::class_<ZeroBaseline, PDFBaseline>
         zerobaseline(m, "ZeroBaseline", doc_ZeroBaseline);

--- a/src/extensions/wrap_PDFBaseline.cpp
+++ b/src/extensions/wrap_PDFBaseline.cpp
@@ -17,10 +17,8 @@
 *
 *****************************************************************************/
 
-#include <boost/python/class.hpp>
-#include <boost/python/def.hpp>
-#include <boost/python/copy_const_reference.hpp>
-#include <boost/python/register_ptr_to_python.hpp>
+#include <nanobind/nanobind.h>
+#include <nanobind/trampoline.h>
 
 #include <diffpy/srreal/PDFBaseline.hpp>
 #include <diffpy/srreal/ZeroBaseline.hpp>
@@ -37,11 +35,11 @@
 #include "srreal_pickling.hpp"
 #include "srreal_registry.hpp"
 
+namespace nb = nanobind;
+
 namespace srrealmodule {
 namespace nswrap_PDFBaseline {
 
-using namespace boost;
-using namespace boost::python;
 using namespace diffpy::srreal;
 
 // docstrings ----------------------------------------------------------------
@@ -72,28 +70,49 @@ PDF baseline function equal to (slope * r).\n\
 // Helper class allows overload of the PDFBaseline methods from Python.
 
 class PDFBaselineWrap :
-    public PDFBaseline,
-    public wrapper_srreal<PDFBaseline>
+    public PDFBaseline
 {
     public:
+
+        NB_TRAMPOLINE(PDFBaseline, 4);
 
         // HasClassRegistry methods
 
         PDFBaselinePtr create() const
         {
-            object rv = this->get_pure_virtual_override("create")();
+            nb::gil_scoped_acquire gil;
+            nb::detail::ticket ticket(nb_trampoline, "create", true);
+
+            if (!ticket.key.is_valid()) 
+            {
+                throw nb::type_error(
+                    "pure virtual method PDFBaseline.create() called"
+                );
+            }
+
+            nb::object rv = nb_trampoline.base().attr(ticket.key)();
             return mconfigurator.fetch(rv);
         }
 
         PDFBaselinePtr clone() const
         {
-            return this->get_pure_virtual_override("clone")();
+            NB_OVERRIDE_PURE(clone);
         }
 
         const std::string& type() const
         {
-            python::object tp = this->get_pure_virtual_override("type")();
-            mtype = python::extract<std::string>(tp);
+            nb::gil_scoped_acquire gil;
+            nb::detail::ticket ticket(nb_trampoline, "type", true);
+
+            if (!ticket.key.is_valid()) 
+            {
+                throw nb::type_error(
+                    "pure virtual method PDFBaseline.type() called"
+                );
+            }
+
+            nb::object tp = nb_trampoline.base().attr(ticket.key)();
+            mtype = nb::cast<std::string>(tp);
             return mtype;
         }
 
@@ -101,7 +120,7 @@ class PDFBaselineWrap :
 
         double operator()(const double& x) const
         {
-            return this->get_pure_virtual_override("__call__")(x);
+            NB_OVERRIDE_PURE_NAME("__call__", operator(), x);
         }
 
     protected:
@@ -130,7 +149,7 @@ class PDFBaselineWrap :
 };  // class PDFBaselineWrap
 
 
-object callnparray(const PDFBaseline* obj, object& x)
+nb::object callnparray(const PDFBaseline* obj, nb::object& x)
 {
     NumPyArray_DoublePtr xx = extractNumPyDoubleArray(x);
     NumPyArray_DoublePtr yy = createNumPyDoubleArrayLike(xx.first);
@@ -145,30 +164,32 @@ object callnparray(const PDFBaseline* obj, object& x)
 
 // Wrapper definition --------------------------------------------------------
 
-void wrap_PDFBaseline()
+void wrap_PDFBaseline(nb::module_& m)
 {
     using namespace nswrap_PDFBaseline;
     using diffpy::Attributes;
-    namespace bp = boost::python;
 
-    class_<PDFBaselineWrap, bases<Attributes>, noncopyable>
-        pdfbaseline("PDFBaseline", doc_PDFBaseline);
+    nb::class_<PDFBaseline, Attributes, PDFBaselineWrap>
+        pdfbaseline(m, "PDFBaseline", nb::dynamic_attr(), doc_PDFBaseline);
     wrap_registry_methods(pdfbaseline)
+        .def(nb::init<>())
         .def("__call__", callnparray,
-                bp::arg("r_array"))
+                nb::arg("r_array"))
         .def("__call__", &PDFBaseline::operator(),
-                bp::arg("r"), doc_PDFBaseline___call__)
-        .def_pickle(SerializationPickleSuite<PDFBaseline,DICT_PICKLE>())
+                nb::arg("r"), doc_PDFBaseline___call__)
         ;
+        SerializationPickleSuite<PDFBaseline, DICT_PICKLE>::bind(pdfbaseline);
 
-    register_ptr_to_python<PDFBaselinePtr>();
-
-    class_<ZeroBaseline, bases<PDFBaseline> >(
-            "ZeroBaseline", doc_ZeroBaseline)
-        .def_pickle(SerializationPickleSuite<ZeroBaseline>());
-    class_<LinearBaseline, bases<PDFBaseline> >(
-            "LinearBaseline", doc_ZeroBaseline)
-        .def_pickle(SerializationPickleSuite<LinearBaseline>());
+    nb::class_<ZeroBaseline, PDFBaseline>
+        zerobaseline(m, "ZeroBaseline", doc_ZeroBaseline);
+    zerobaseline
+        .def(nb::init<>());
+        SerializationPickleSuite<ZeroBaseline, DICT_IGNORE>::bind(zerobaseline);
+    nb::class_<LinearBaseline, PDFBaseline>
+        linearbaseline(m,"LinearBaseline", doc_LinearBaseline);
+    linearbaseline
+        .def(nb::init<>());
+        SerializationPickleSuite<LinearBaseline, DICT_IGNORE>::bind(linearbaseline);
 
 }
 

--- a/src/extensions/wrap_PDFBaseline.cpp
+++ b/src/extensions/wrap_PDFBaseline.cpp
@@ -188,12 +188,12 @@ void wrap_PDFBaseline(nb::module_& m)
         zerobaseline(m, "ZeroBaseline", doc_ZeroBaseline);
     zerobaseline
         .def(nb::init<>());
-        SerializationPickleSuite<ZeroBaseline, DICT_IGNORE>::bind(zerobaseline);
+        SerializationPickleSuite<ZeroBaseline, DICT_GUARD>::bind(zerobaseline);
     nb::class_<LinearBaseline, PDFBaseline>
         linearbaseline(m,"LinearBaseline", doc_LinearBaseline);
     linearbaseline
         .def(nb::init<>());
-        SerializationPickleSuite<LinearBaseline, DICT_IGNORE>::bind(linearbaseline);
+        SerializationPickleSuite<LinearBaseline, DICT_GUARD>::bind(linearbaseline);
 
 }
 

--- a/src/extensions/wrap_PDFBaseline.cpp
+++ b/src/extensions/wrap_PDFBaseline.cpp
@@ -84,7 +84,7 @@ class PDFBaselineWrap :
             nb::gil_scoped_acquire gil;
             nb::detail::ticket ticket(nb_trampoline, "create", true);
 
-            if (!ticket.key.is_valid()) 
+            if (!ticket.key.is_valid())
             {
                 throw nb::type_error(
                     "pure virtual method PDFBaseline.create() called"
@@ -105,7 +105,7 @@ class PDFBaselineWrap :
             nb::gil_scoped_acquire gil;
             nb::detail::ticket ticket(nb_trampoline, "type", true);
 
-            if (!ticket.key.is_valid()) 
+            if (!ticket.key.is_valid())
             {
                 throw nb::type_error(
                     "pure virtual method PDFBaseline.type() called"

--- a/src/extensions/wrap_PDFCalculators.cpp
+++ b/src/extensions/wrap_PDFCalculators.cpp
@@ -163,6 +163,35 @@ Return a tuple of (f, qstep).  These can be used with the complementary\n\
 fftftog function to recover the original signal g.\n\
 ";
 
+const char* doc_PeakWidthModelOwner_peakwidthmodel = "\
+PeakWidthModel object used for calculating the FWHM of the PDF peaks.\n\
+This attribute can be assigned either a PeakWidthModel-derived object\n\
+or a string name of a registered PeakWidthModel class.\n\
+Use PeakWidthModel.getRegisteredTypes() for a set of registered names.\n\
+";
+
+const char* doc_ScatteringFactorTableOwner_scatteringfactortable = "\
+ScatteringFactorTable object used for a lookup of scattering factors.\n\
+This can be also set with the setScatteringFactorTableByType method.\n\
+";
+
+const char* doc_ScatteringFactorTableOwner_setScatteringFactorTableByType = "\
+Set internal ScatteringFactorTable according to specified string type.\n\
+\n\
+tp   -- string identifier of a registered ScatteringFactorTable type.\n\
+    Use ScatteringFactorTable.getRegisteredTypes for the allowed values.\n\
+\n\
+Deprecated: This method is deprecated and will be removed in the 2.0.0 release.\n\
+Use direct assignment to the `scatteringfactortable` property instead, for example:\n\
+    obj.scatteringfactortable = SFTNeutron()\n\
+No return value.\n\
+";
+
+const char* doc_ScatteringFactorTableOwner_getRadiationType = "\
+Return string identifying the radiation type.\n\
+'X' for x-rays, 'N' for neutrons.\n\
+";
+
 // wrappers ------------------------------------------------------------------
 
 DECLARE_PYARRAY_METHOD_WRAPPER(getPDF, getPDF_asarray)
@@ -266,7 +295,55 @@ PDFEnvelopePtr getoneenvelope(T& obj, const std::string& tp)
 }
 
 
+// wrappers for PeakWidthModelOwner behavior
+
+template <class T>
+PeakWidthModelPtr getpeakwidthmodel(T& obj)
+{
+    return obj.getPeakWidthModel();
+}
+
+DECLARE_BYTYPE_SETTER_WRAPPER(setPeakWidthModel, setpeakwidthmodel)
+
+// wrappers for ScatteringFactorTableOwner behavior
+
+template <class T>
+ScatteringFactorTablePtr getscatteringfactortable(T& obj)
+{
+    return obj.getScatteringFactorTable();
+}
+
+DECLARE_BYTYPE_SETTER_WRAPPER(setScatteringFactorTable, setscatteringfactortable)
+
+template <class T>
+void setscatteringfactortablebytype(T& obj, const std::string& tp)
+{
+    try
+    {
+        nb::object warnings = nb::module_::import_("warnings");
+        nb::object builtins = nb::module_::import_("builtins");
+        nb::object DeprecationWarning = builtins.attr("DeprecationWarning");
+        warnings.attr("warn")(
+            std::string("setScatteringFactorTableByType is deprecated; "
+                    "assign the 'scatteringfactortable' property directly, for example:\n"
+                    "obj.scatteringfactortable = SFTNeutron()"),
+            DeprecationWarning,
+            2);
+    }
+    catch (...) { /* don't let warnings break the binding */ }
+    obj.setScatteringFactorTableByType(tp);
+}
+
+template <class T>
+std::string getradiationtype(T& obj)
+{
+    return obj.getRadiationType();
+}
+
+
 // wrap shared methods and attributes of PDFCalculators
+// TODO: since nanobind doesn't allow multiple inheritance,
+// we may need to introduce a header to better address this.
 
 template <class W, class C>
 C& wrap_PDFCommon(C& cls)
@@ -293,6 +370,23 @@ C& wrap_PDFCommon(C& cls)
                 nb::arg("tp"), doc_PDFCommon_getEnvelope)
         .def("clearEnvelopes", &W::clearEnvelopes,
                 doc_PDFCommon_clearEnvelopes)
+        // PeakWidthModelOwner functions
+        .def_prop_rw("peakwidthmodel",
+                getpeakwidthmodel<W>,
+                setpeakwidthmodel<W, PeakWidthModel>,
+                doc_PeakWidthModelOwner_peakwidthmodel)
+        // ScatteringFactorTableOwner behavior
+        .def_prop_rw("scatteringfactortable",
+                getscatteringfactortable<W>,
+                setscatteringfactortable<W, ScatteringFactorTable>,
+                doc_ScatteringFactorTableOwner_scatteringfactortable)
+        .def("setScatteringFactorTableByType",
+                setscatteringfactortablebytype<W>,
+                nb::arg("tp"),
+                doc_ScatteringFactorTableOwner_setScatteringFactorTableByType)
+        .def("getRadiationType",
+                getradiationtype<W>,
+                doc_ScatteringFactorTableOwner_getRadiationType)
         ;
     return cls;
 }

--- a/src/extensions/wrap_PDFCalculators.cpp
+++ b/src/extensions/wrap_PDFCalculators.cpp
@@ -20,7 +20,10 @@
 
 #include <diffpy/srreal/DebyePDFCalculator.hpp>
 #include <diffpy/srreal/PDFCalculator.hpp>
-
+#include <diffpy/srreal/GaussianProfile.hpp>
+#include <diffpy/srreal/JeongPeakWidth.hpp>
+#include <diffpy/srreal/LinearBaseline.hpp>
+#include <diffpy/srreal/SFTXray.hpp>
 #include "srreal_converters.hpp"
 #include "srreal_pickling.hpp"
 
@@ -423,32 +426,46 @@ nb::tuple getstate_super(nb::object obj)
 {
     // obtain C++ state without PDFEnvelopes
     nb::object envlps = obj.attr("envelopes");
-    obj.attr("clearEnvelopes")();
-    assert(nb::len(obj.attr("envelopes")) == 0);
-    nb::tuple super_state = Super::getstate(obj);
-    obj.attr("envelopes") = envlps;
-    assert(nb::len(obj.attr("envelopes")) == nb::len(envlps));
-    return nb::make_tuple(super_state);
+    bool needs_restore = false;
+    try
+    {
+        obj.attr("clearEnvelopes")();
+        needs_restore = true;
+        assert(nb::len(obj.attr("envelopes")) == 0);
+        nb::tuple super_state = Super::getstate(obj);
+        obj.attr("envelopes") = envlps;
+        needs_restore = false;
+        assert(nb::len(obj.attr("envelopes")) == nb::len(envlps));
+        return nb::make_tuple(super_state);
+    }
+    catch (...)
+    {
+        if (needs_restore)
+        {
+            obj.attr("envelopes") = envlps;
+        }
+        throw;
+    }
 }
 
 
-nb::tuple getstate_common(nb::object obj)
+nb::tuple getstate_common(
+        nb::object obj, nb::object pwm_state, nb::object sft_state)
 {
-    auto resolve_pwm = resolve_state_object<PeakWidthModel>;
-    auto resolve_sft = resolve_state_object<ScatteringFactorTable>;
     nb::tuple rv = make_tuple(
-            resolve_pwm(obj.attr("peakwidthmodel")),
-            resolve_sft(obj.attr("scatteringfactortable")),
+            pwm_state,
+            sft_state,
             obj.attr("envelopes")
             );
     return rv;
 }
 
 
-void setstate_common(nb::object obj, nb::tuple state, size_t& pos)
+template <class T>
+void setstate_common(T& calc, nb::object obj, nb::tuple state, size_t& pos)
 {
-    assign_state_object(obj.attr("peakwidthmodel"), state[pos++]);
-    assign_state_object(obj.attr("scatteringfactortable"), state[pos++]);
+    assign_pointer_state(calc.getPeakWidthModel(), state[pos++]);
+    assign_pointer_state(calc.getScatteringFactorTable(), state[pos++]);
     assert(nb::len(obj.attr("envelopes")) == 0);
     obj.attr("envelopes") = nb::borrow<nb::object>(state[pos++]);
 }
@@ -469,17 +486,38 @@ class DebyePDFCalculatorPickleSuite :
             cls
                 .def("__getstate__", getstate)
                 .def("__setstate__", setstate)
+                .def("__reduce__", reduce)
                 ;
+            cls.attr("__getstate_manages_dict__") = nb::none();
         }
         
 
         static nb::tuple getstate(nb::object obj)
         {
-            nb::tuple rv(
-                    getstate_super<Super>(obj) +
-                    getstate_common(obj)
-                    );
-            return rv;
+            DebyePDFCalculator& calc = nb::cast<DebyePDFCalculator&>(obj);
+            ScopedSharedPtrReplacement<PeakWidthModel> pwm(
+                calc.getPeakWidthModel(), PeakWidthModelPtr(new JeongPeakWidth));
+            ScopedSharedPtrReplacement<ScatteringFactorTable> sft(
+                calc.getScatteringFactorTable(),
+                ScatteringFactorTablePtr(new SFTXray));
+            try
+            {
+                nb::tuple rv(
+                        getstate_super<Super>(obj) +
+                        getstate_common(
+                            obj,
+                            pwm.state_object(),
+                            sft.state_object()
+                            )
+                        );
+                return rv;
+            }
+            catch (...)
+            {
+                sft.restore();
+                pwm.restore();
+                throw;
+            }
         }
 
 
@@ -489,9 +527,15 @@ class DebyePDFCalculatorPickleSuite :
             // restore the state using boost serialization
             nb::tuple st0(state[0]);
             Super::setstate(obj, st0);
-            // other items are non-None only when restoring Python class
+            // restore components that were kept out of Boost serialization
+            DebyePDFCalculator& calc = nb::cast<DebyePDFCalculator&>(obj);
             size_t pos = 1;
-            setstate_common(obj, state, pos);
+            setstate_common(calc, obj, state, pos);
+        }
+
+        static nb::tuple reduce(nb::object obj)
+        {
+            return Super::reduce(obj);
         }
 };
 
@@ -511,21 +555,48 @@ class PDFCalculatorPickleSuite :
             cls
                 .def("__getstate__", getstate)
                 .def("__setstate__", setstate)
+                .def("__reduce__", reduce)
                 ;
+            cls.attr("__getstate_manages_dict__") = nb::none();
         }
 
         static nb::tuple getstate(nb::object obj)
         {
+            PDFCalculator& calc = nb::cast<PDFCalculator&>(obj);
+            ScopedSharedPtrReplacement<PeakWidthModel> pwm(
+                calc.getPeakWidthModel(), PeakWidthModelPtr(new JeongPeakWidth));
+            ScopedSharedPtrReplacement<ScatteringFactorTable> sft(
+                calc.getScatteringFactorTable(),
+                ScatteringFactorTablePtr(new SFTXray));
+            ScopedSharedPtrReplacement<PeakProfile> peakprofile(
+                calc.getPeakProfile(), PeakProfilePtr(new GaussianProfile));
+            ScopedSharedPtrReplacement<PDFBaseline> baseline(
+                calc.getBaseline(), PDFBaselinePtr(new LinearBaseline));
             nb::tuple mystate = make_tuple(
-                    resolve_state_object<PeakProfile>(obj.attr("peakprofile")),
-                    resolve_state_object<PDFBaseline>(obj.attr("baseline"))
+                    peakprofile.state_object(),
+                    baseline.state_object()
                     );
-            nb::tuple rv(
-                    getstate_super<Super>(obj) +
-                    getstate_common(obj) +
-                    mystate
-                    );
-            return rv;
+            try
+            {
+                nb::tuple rv(
+                        getstate_super<Super>(obj) +
+                        getstate_common(
+                            obj,
+                            pwm.state_object(),
+                            sft.state_object()
+                            ) +
+                        mystate
+                        );
+                return rv;
+            }
+            catch (...)
+            {
+                baseline.restore();
+                peakprofile.restore();
+                sft.restore();
+                pwm.restore();
+                throw;
+            }
         }
 
 
@@ -535,11 +606,17 @@ class PDFCalculatorPickleSuite :
             // restore the state using boost serialization
             nb::tuple st0(state[0]);
             Super::setstate(obj, st0);
-            // other items are non-None only when restoring Python class
+            // restore components that were kept out of Boost serialization
+            PDFCalculator& calc = nb::cast<PDFCalculator&>(obj);
             size_t pos = 1;
-            setstate_common(obj, state, pos);
-            assign_state_object(obj.attr("peakprofile"), state[pos++]);
-            assign_state_object(obj.attr("baseline"), state[pos++]);
+            setstate_common(calc, obj, state, pos);
+            assign_pointer_state(calc.getPeakProfile(), state[pos++]);
+            assign_pointer_state(calc.getBaseline(), state[pos++]);
+        }
+
+        static nb::tuple reduce(nb::object obj)
+        {
+            return Super::reduce(obj);
         }
 };
 

--- a/src/extensions/wrap_PDFCalculators.cpp
+++ b/src/extensions/wrap_PDFCalculators.cpp
@@ -472,7 +472,7 @@ void setstate_common(T& calc, nb::object obj, nb::tuple state, size_t& pos)
 
 
 class DebyePDFCalculatorPickleSuite :
-    public PairQuantityPickleSuite<DebyePDFCalculator, DICT_IGNORE>
+    public PairQuantityPickleSuite<DebyePDFCalculator, DICT_GUARD>
 {
     private:
 
@@ -541,7 +541,7 @@ class DebyePDFCalculatorPickleSuite :
 
 
 class PDFCalculatorPickleSuite :
-    public PairQuantityPickleSuite<PDFCalculator, DICT_IGNORE>
+    public PairQuantityPickleSuite<PDFCalculator, DICT_GUARD>
 {
     private:
 

--- a/src/extensions/wrap_PDFCalculators.cpp
+++ b/src/extensions/wrap_PDFCalculators.cpp
@@ -16,9 +16,7 @@
 *
 *****************************************************************************/
 
-#include <boost/python/class.hpp>
-#include <boost/python/def.hpp>
-#include <boost/python/stl_iterator.hpp>
+#include <nanobind/nanobind.h>
 
 #include <diffpy/srreal/DebyePDFCalculator.hpp>
 #include <diffpy/srreal/PDFCalculator.hpp>
@@ -26,10 +24,11 @@
 #include "srreal_converters.hpp"
 #include "srreal_pickling.hpp"
 
+namespace nb = nanobind;
+
 namespace srrealmodule {
 namespace nswrap_PDFCalculators {
 
-using namespace boost::python;
 using namespace diffpy::srreal;
 
 // docstrings ----------------------------------------------------------------
@@ -193,36 +192,36 @@ DECLARE_BYTYPE_SETTER_WRAPPER(setBaseline, setbaseline)
 
 // wrappers for the envelopes property
 
-PDFEnvelopePtr pyobjtoenvelope(object evp)
+PDFEnvelopePtr pyobjtoenvelope(nb::object evp)
 {
-    extract<std::string> tp(evp);
-    if (tp.check())  return PDFEnvelope::createByType(tp());
-    PDFEnvelopePtr rv = extract<PDFEnvelopePtr>(evp);
-    return rv;
+    std::string tp;
+    if (nb::try_cast<std::string>(evp, tp, false))
+    {
+        return PDFEnvelope::createByType(tp);
+    }
+    return nb::cast<PDFEnvelopePtr>(evp);
 }
 
 
 template <class T>
-tuple getenvelopes(T& obj)
+nb::tuple getenvelopes(T& obj)
 {
     std::set<std::string> etps = obj.usedEnvelopeTypes();
     std::set<std::string>::const_iterator tpi;
-    list elst;
+    nb::list elst;
     for (tpi = etps.begin(); tpi != etps.end(); ++tpi)
     {
         elst.append(obj.getEnvelopeByType(*tpi));
     }
-    tuple rv(elst);
-    return rv;
+    return nb::tuple(elst);
 }
 
 template <class T>
-void setenvelopes(T& obj, object evps)
+void setenvelopes(T& obj, nb::object evps)
 {
-    stl_input_iterator<object> eit(evps), end;
     // first check if all evps items can be converted to PDFEnvelopePtr
     std::list<PDFEnvelopePtr> elst;
-    for (; eit != end; ++eit)  elst.push_back(pyobjtoenvelope(*eit));
+    for (nb::handle evp : evps)  elst.push_back(pyobjtoenvelope(nb::borrow<nb::object>(evp)));
     // if that worked, overwrite the original envelopes
     obj.clearEnvelopes();
     std::list<PDFEnvelopePtr>::iterator eii = elst.begin();
@@ -232,27 +231,30 @@ void setenvelopes(T& obj, object evps)
 // wrapper for the usedenvelopetypes
 
 template <class T>
-tuple getusedenvelopetypes(T& obj)
+nb::tuple getusedenvelopetypes(T& obj)
 {
-    tuple rv(usedEnvelopeTypes_aslist<T>(obj));
+    nb::tuple rv(usedEnvelopeTypes_aslist<T>(obj));
     return rv;
 }
 
 template <class T>
-void addenvelope(T& obj, object evp)
+void addenvelope(T& obj, nb::object evp)
 {
     PDFEnvelopePtr e = pyobjtoenvelope(evp);
     obj.addEnvelope(e);
 }
 
 template <class T>
-void popenvelope(T& obj, object evp)
+void popenvelope(T& obj, nb::object evp)
 {
-    extract<std::string> tp(evp);
-    if (tp.check())  obj.popEnvelopeByType(tp());
+    std::string tp;
+    if (nb::try_cast<std::string>(evp, tp, false))
+    {
+        obj.popEnvelopeByType(tp);
+    }
     else
     {
-        PDFEnvelopePtr e = extract<PDFEnvelopePtr>(evp);
+        PDFEnvelopePtr e = nb::cast<PDFEnvelopePtr>(evp);
         obj.popEnvelope(e);
     }
 }
@@ -266,88 +268,81 @@ PDFEnvelopePtr getoneenvelope(T& obj, const std::string& tp)
 
 // wrap shared methods and attributes of PDFCalculators
 
-template <class C>
-C& wrap_PDFCommon(C& boostpythonclass)
+template <class W, class C>
+C& wrap_PDFCommon(C& cls)
 {
-    namespace bp = boost::python;
-    typedef typename C::wrapped_type W;
-    boostpythonclass
+    cls
         // result vectors
-        .add_property("pdf", getPDF_asarray<W>,
-                doc_PDFCommon_pdf)
-        .add_property("rdf", getRDF_asarray<W>,
-                doc_PDFCommon_rdf)
-        .add_property("rgrid", getRgrid_asarray<W>,
-                doc_PDFCommon_rgrid)
-        .add_property("fq", getF_asarray<W>,
-                doc_PDFCommon_fq)
-        .add_property("qgrid", getQgrid_asarray<W>,
-                doc_PDFCommon_qgrid)
+        .def_prop_ro("pdf", getPDF_asarray<W>, doc_PDFCommon_pdf)
+        .def_prop_ro("rdf", getRDF_asarray<W>, doc_PDFCommon_rdf)
+        .def_prop_ro("rgrid", getRgrid_asarray<W>, doc_PDFCommon_rgrid)
+        .def_prop_ro("fq", getF_asarray<W>, doc_PDFCommon_fq)
+        .def_prop_ro("qgrid", getQgrid_asarray<W>, doc_PDFCommon_qgrid)
         // PDF envelopes
-        .add_property("envelopes",
+        .def_prop_rw("envelopes",
                 getenvelopes<W>, setenvelopes<W>,
                 doc_PDFCommon_envelopes)
-        .add_property("usedenvelopetypes",
+        .def_prop_ro("usedenvelopetypes",
                 getusedenvelopetypes<W>,
                 doc_PDFCommon_usedenvelopetypes)
         .def("addEnvelope", addenvelope<W>,
-                bp::arg("envlp"), doc_PDFCommon_addEnvelope)
+                nb::arg("envlp"), doc_PDFCommon_addEnvelope)
         .def("popEnvelope", popenvelope<W>,
-                doc_PDFCommon_popEnvelope)
+                nb::arg("envlp"), doc_PDFCommon_popEnvelope)
         .def("getEnvelope", getoneenvelope<W>,
-                bp::arg("tp"), doc_PDFCommon_getEnvelope)
+                nb::arg("tp"), doc_PDFCommon_getEnvelope)
         .def("clearEnvelopes", &W::clearEnvelopes,
                 doc_PDFCommon_clearEnvelopes)
         ;
-    return boostpythonclass;
+    return cls;
 }
 
 // local helper for converting python object to a quantity type
 
-tuple fftftog_array_step(object f, double qstep, double qmin)
+nb::tuple fftftog_array_step(nb::object f, double qstep, double qmin)
 {
     QuantityType f0;
     const QuantityType& f1 = extractQuantityType(f, f0);
     QuantityType g = fftftog(f1, qstep, qmin);
-    object ga = convertToNumPyArray(g);
+    nb::object ga = convertToNumPyArray(g);
     double qmaxpad = g.size() * qstep;
     double rstep = (qmaxpad > 0) ? (M_PI / qmaxpad) : 0.0;
-    return make_tuple(ga, rstep);
+    return nb::make_tuple(ga, rstep);
 }
 
 
-tuple fftgtof_array_step(object g, double rstep, double rmin)
+nb::tuple fftgtof_array_step(nb::object g, double rstep, double rmin)
 {
     QuantityType g0;
     const QuantityType& g1 = extractQuantityType(g, g0);
     QuantityType f = fftgtof(g1, rstep, rmin);
-    object fa = convertToNumPyArray(f);
+    nb::object fa = convertToNumPyArray(f);
     double rmaxpad = f.size() * rstep;
     double qstep = (rmaxpad > 0) ? (M_PI / rmaxpad) : 0.0;
-    return make_tuple(fa, qstep);
+    return nb::make_tuple(fa, qstep);
 }
 
 // pickling support ----------------------------------------------------------
 
 template <class Super>
-tuple getstate_super(object& obj)
+nb::tuple getstate_super(nb::object obj)
 {
     // obtain C++ state without PDFEnvelopes
-    object envlps = obj.attr("envelopes");
+    nb::object envlps = obj.attr("envelopes");
     obj.attr("clearEnvelopes")();
-    assert(len(obj.attr("envelopes")) == 0);
-    tuple rv(make_tuple(Super::getstate(obj)));
+    assert(nb::len(obj.attr("envelopes")) == 0);
+    nb::tuple super_state = Super::getstate(obj);
     obj.attr("envelopes") = envlps;
-    assert(len(obj.attr("envelopes")) == len(envlps));
-    return rv;
+    assert(nb::len(obj.attr("envelopes")) == nb::len(envlps));
+    return nb::make_tuple(super_state);
 }
 
 
-tuple getstate_common(object& obj)
+nb::tuple getstate_common(nb::object obj)
 {
     auto resolve_pwm = resolve_state_object<PeakWidthModel>;
     auto resolve_sft = resolve_state_object<ScatteringFactorTable>;
-    tuple rv = make_tuple(
+    nb::tuple rv = make_tuple(
             resolve_pwm(obj.attr("peakwidthmodel")),
             resolve_sft(obj.attr("scatteringfactortable")),
             obj.attr("envelopes")
@@ -356,13 +351,12 @@ tuple getstate_common(object& obj)
 }
 
 
-template <class Iter>
-void setstate_common(object& obj, Iter& st)
+void setstate_common(nb::object obj, nb::tuple state, size_t& pos)
 {
-    assign_state_object(obj.attr("peakwidthmodel"), *(++st));
-    assign_state_object(obj.attr("scatteringfactortable"), *(++st));
-    assert(len(obj.attr("envelopes")) == 0);
-    obj.attr("envelopes") = *(++st);
+    assign_state_object(obj.attr("peakwidthmodel"), state[pos++]);
+    assign_state_object(obj.attr("scatteringfactortable"), state[pos++]);
+    assert(nb::len(obj.attr("envelopes")) == 0);
+    obj.attr("envelopes") = nb::borrow<nb::object>(state[pos++]);
 }
 
 
@@ -375,9 +369,19 @@ class DebyePDFCalculatorPickleSuite :
 
     public:
 
-        static tuple getstate(object obj)
+        template <class C>
+        static void bind(C& cls)
         {
-            tuple rv(
+            cls
+                .def("__getstate__", getstate)
+                .def("__setstate__", setstate)
+                ;
+        }
+        
+
+        static nb::tuple getstate(nb::object obj)
+        {
+            nb::tuple rv(
                     getstate_super<Super>(obj) +
                     getstate_common(obj)
                     );
@@ -385,15 +389,15 @@ class DebyePDFCalculatorPickleSuite :
         }
 
 
-        static void setstate(object obj, tuple state)
+        static void setstate(nb::object obj, nb::tuple state)
         {
             ensure_tuple_length(state, 4);
             // restore the state using boost serialization
-            tuple st0 = extract<tuple>(state[0]);
+            nb::tuple st0(state[0]);
             Super::setstate(obj, st0);
             // other items are non-None only when restoring Python class
-            stl_input_iterator<object> st(state);
-            setstate_common(obj, st);
+            size_t pos = 1;
+            setstate_common(obj, state, pos);
         }
 };
 
@@ -407,13 +411,22 @@ class PDFCalculatorPickleSuite :
 
     public:
 
-        static tuple getstate(object obj)
+        template <class C>
+        static void bind(C& cls)
         {
-            tuple mystate = make_tuple(
+            cls
+                .def("__getstate__", getstate)
+                .def("__setstate__", setstate)
+                ;
+        }
+
+        static nb::tuple getstate(nb::object obj)
+        {
+            nb::tuple mystate = make_tuple(
                     resolve_state_object<PeakProfile>(obj.attr("peakprofile")),
                     resolve_state_object<PDFBaseline>(obj.attr("baseline"))
                     );
-            tuple rv(
+            nb::tuple rv(
                     getstate_super<Super>(obj) +
                     getstate_common(obj) +
                     mystate
@@ -422,17 +435,17 @@ class PDFCalculatorPickleSuite :
         }
 
 
-        static void setstate(object obj, tuple state)
+        static void setstate(nb::object obj, nb::tuple state)
         {
             ensure_tuple_length(state, 6);
             // restore the state using boost serialization
-            tuple st0 = extract<tuple>(state[0]);
+            nb::tuple st0(state[0]);
             Super::setstate(obj, st0);
             // other items are non-None only when restoring Python class
-            stl_input_iterator<object> st(state);
-            setstate_common(obj, st);
-            assign_state_object(obj.attr("peakprofile"), *(++st));
-            assign_state_object(obj.attr("baseline"), *(++st));
+            size_t pos = 1;
+            setstate_common(obj, state, pos);
+            assign_state_object(obj.attr("peakprofile"), state[pos++]);
+            assign_state_object(obj.attr("baseline"), state[pos++]);
         }
 };
 
@@ -440,47 +453,47 @@ class PDFCalculatorPickleSuite :
 
 // Wrapper definition --------------------------------------------------------
 
-void wrap_PDFCalculators()
+void wrap_PDFCalculators(nb::module_& m)
 {
     using namespace nswrap_PDFCalculators;
-    namespace bp = boost::python;
 
+    // TODO: some types are flattened, we may need to add bindings manually
     // DebyePDFCalculator
-    class_<DebyePDFCalculator,
-        bases<PairQuantity, PeakWidthModelOwner, ScatteringFactorTableOwner> >
-            dbpdfc_class("DebyePDFCalculator", doc_DebyePDFCalculator);
-    wrap_PDFCommon(dbpdfc_class)
+    nb::class_<DebyePDFCalculator, PairQuantity>
+            dbpdfc_class(m, "DebyePDFCalculator", doc_DebyePDFCalculator);
+    wrap_PDFCommon<DebyePDFCalculator>(dbpdfc_class)
+        .def(nb::init<>())
         .def("setOptimumQstep", &DebyePDFCalculator::setOptimumQstep,
                 doc_DebyePDFCalculator_setOptimumQstep)
         .def("isOptimumQstep", &DebyePDFCalculator::isOptimumQstep,
                 doc_DebyePDFCalculator_isOptimumQstep)
-        .def_pickle(DebyePDFCalculatorPickleSuite())
         ;
+        DebyePDFCalculatorPickleSuite::bind(dbpdfc_class);
 
     // PDFCalculator
-    class_<PDFCalculator,
-        bases<PairQuantity, PeakWidthModelOwner, ScatteringFactorTableOwner> >
-        pdfc_class("PDFCalculator", doc_PDFCalculator);
-    wrap_PDFCommon(pdfc_class)
+    nb::class_<PDFCalculator, PairQuantity>
+        pdfc_class(m, "PDFCalculator", doc_PDFCalculator);
+    wrap_PDFCommon<PDFCalculator>(pdfc_class)
+        .def(nb::init<>())
         // PDF peak profile
-        .add_property("peakprofile",
+        .def_prop_rw("peakprofile",
                 getpeakprofile,
                 setpeakprofile<PDFCalculator,PeakProfile>,
                 doc_PDFCalculator_peakprofile)
         // PDF baseline
-        .add_property("baseline",
+        .def_prop_rw("baseline",
                 getbaseline,
                 setbaseline<PDFCalculator,PDFBaseline>,
                 doc_PDFCalculator_baseline)
-        .def_pickle(PDFCalculatorPickleSuite())
         ;
+        PDFCalculatorPickleSuite::bind(pdfc_class);
 
     // FFT functions
-    def("fftftog", fftftog_array_step,
-            (bp::arg("f"), bp::arg("qstep"), bp::arg("qmin")=0.0),
+    m.def("fftftog", fftftog_array_step,
+            nb::arg("f"), nb::arg("qstep"), nb::arg("qmin") = 0.0,
             doc_fftftog);
-    def("fftgtof", fftgtof_array_step,
-            (bp::arg("g"), bp::arg("rstep"), bp::arg("rmin")=0.0),
+    m.def("fftgtof", fftgtof_array_step,
+            nb::arg("g"), nb::arg("rstep"), nb::arg("rmin") = 0.0,
             doc_fftgtof);
 
 }

--- a/src/extensions/wrap_PDFCalculators.cpp
+++ b/src/extensions/wrap_PDFCalculators.cpp
@@ -490,7 +490,7 @@ class DebyePDFCalculatorPickleSuite :
                 ;
             cls.attr("__getstate_manages_dict__") = nb::none();
         }
-        
+
 
         static nb::tuple getstate(nb::object obj)
         {

--- a/src/extensions/wrap_PDFEnvelope.cpp
+++ b/src/extensions/wrap_PDFEnvelope.cpp
@@ -221,25 +221,25 @@ void wrap_PDFEnvelope(nb::module_ &m)
     qresenvelope
         .def(nb::init<>())
         ;
-        SerializationPickleSuite<QResolutionEnvelope, DICT_IGNORE>::bind(qresenvelope);
+        SerializationPickleSuite<QResolutionEnvelope, DICT_GUARD>::bind(qresenvelope);
     nb::class_<ScaleEnvelope, PDFEnvelope> scaleenvelope(m,
             "ScaleEnvelope", doc_ScaleEnvelope);
     scaleenvelope
         .def(nb::init<>())
         ;
-        SerializationPickleSuite<ScaleEnvelope, DICT_IGNORE>::bind(scaleenvelope);
+        SerializationPickleSuite<ScaleEnvelope, DICT_GUARD>::bind(scaleenvelope);
     nb::class_<SphericalShapeEnvelope, PDFEnvelope> sphshapeenvelope(m,
             "SphericalShapeEnvelope", doc_SphericalShapeEnvelope);
     sphshapeenvelope
         .def(nb::init<>())
         ;
-        SerializationPickleSuite<SphericalShapeEnvelope, DICT_IGNORE>::bind(sphshapeenvelope);
+        SerializationPickleSuite<SphericalShapeEnvelope, DICT_GUARD>::bind(sphshapeenvelope);
     nb::class_<StepCutEnvelope, PDFEnvelope> stepcutenvelope(m,
             "StepCutEnvelope", doc_StepCutEnvelope);
     stepcutenvelope
         .def(nb::init<>())
         ;
-        SerializationPickleSuite<StepCutEnvelope, DICT_IGNORE>::bind(stepcutenvelope);
+        SerializationPickleSuite<StepCutEnvelope, DICT_GUARD>::bind(stepcutenvelope);
 
 }
 

--- a/src/extensions/wrap_PDFEnvelope.cpp
+++ b/src/extensions/wrap_PDFEnvelope.cpp
@@ -17,10 +17,8 @@
 *
 *****************************************************************************/
 
-#include <boost/python/class.hpp>
-#include <boost/python/def.hpp>
-#include <boost/python/copy_const_reference.hpp>
-#include <boost/python/register_ptr_to_python.hpp>
+#include <nanobind/nanobind.h>
+#include <nanobind/trampoline.h>
 
 #include <diffpy/srreal/PDFEnvelope.hpp>
 #include <diffpy/srreal/QResolutionEnvelope.hpp>
@@ -39,11 +37,11 @@
 #include "srreal_pickling.hpp"
 #include "srreal_registry.hpp"
 
+namespace nb = nanobind;
+
 namespace srrealmodule {
 namespace nswrap_PDFEnvelope {
 
-using namespace boost;
-using namespace boost::python;
 using namespace diffpy::srreal;
 
 // docstrings ----------------------------------------------------------------
@@ -93,43 +91,75 @@ Returns   0 when x > stepcut.\n\
 // Helper class allows overload of the PDFEnvelope methods from Python.
 
 class PDFEnvelopeWrap :
-    public PDFEnvelope,
-    public wrapper_srreal<PDFEnvelope>
+    public PDFEnvelope
 {
     public:
 
+        NB_TRAMPOLINE(PDFEnvelope, 4);
+
         // HasClassRegistry methods
 
-        PDFEnvelopePtr create() const
+        PDFEnvelopePtr create() const override
         {
-            object rv = this->get_pure_virtual_override("create")();
+            nb::gil_scoped_acquire gil;
+            nb::detail::ticket ticket(nb_trampoline, "create", true);
+
+            if (!ticket.key.is_valid()) 
+            {
+                throw nb::type_error(
+                    "pure virtual method PDFEnvelope.create() called"
+                );
+            }
+
+            nb::object rv = nb_trampoline.base().attr(ticket.key)();
             return mconfigurator.fetch(rv);
         }
 
-        PDFEnvelopePtr clone() const
+        PDFEnvelopePtr clone() const override
         {
-            return this->get_pure_virtual_override("clone")();
+            NB_OVERRIDE_PURE(clone);
         }
 
-        const std::string& type() const
+        const std::string& type() const override
         {
-            python::object tp = this->get_pure_virtual_override("type")();
-            mtype = python::extract<std::string>(tp);
+            nb::gil_scoped_acquire gil;
+            nb::detail::ticket ticket(nb_trampoline, "type", true);
+
+            if (!ticket.key.is_valid()) 
+            {
+                throw nb::type_error(
+                    "pure virtual method PDFEnvelope.type() called"
+                );
+            }
+
+            nb::object tp = nb_trampoline.base().attr(ticket.key)();
+            mtype = nb::cast<std::string>(tp);
             return mtype;
         }
 
         // own methods
 
-        double operator()(const double& x) const
+        double operator()(const double& x) const override
         {
-            return this->get_pure_virtual_override("__call__")(x);
+            nb::gil_scoped_acquire gil;
+            nb::detail::ticket ticket(nb_trampoline, "__call__", true);
+
+            if (!ticket.key.is_valid()) 
+            {
+                throw nb::type_error(
+                    "pure virtual method PDFEnvelope.__call__() called"
+                );
+            }
+
+            nb::object rv = nb_trampoline.base().attr(ticket.key)(x);
+            return nb::cast<double>(rv);
         }
 
     protected:
 
         // HasClassRegistry method
 
-        void setupRegisteredObject(PDFEnvelopePtr p) const
+        void setupRegisteredObject(PDFEnvelopePtr p) const override
         {
             mconfigurator.setup(p);
         }
@@ -151,7 +181,7 @@ class PDFEnvelopeWrap :
 };  // class PDFEnvelopeWrap
 
 
-object callnparray(const PDFEnvelope* obj, object& x)
+nb::object callnparray(const PDFEnvelope* obj, nb::object& x)
 {
     NumPyArray_DoublePtr xx = extractNumPyDoubleArray(x);
     NumPyArray_DoublePtr yy = createNumPyDoubleArrayLike(xx.first);
@@ -166,40 +196,46 @@ object callnparray(const PDFEnvelope* obj, object& x)
 
 // Wrapper definition --------------------------------------------------------
 
-void wrap_PDFEnvelope()
+void wrap_PDFEnvelope(nb::module_ &m)
 {
     using namespace nswrap_PDFEnvelope;
     using diffpy::Attributes;
-    namespace bp = boost::python;
 
-    class_<PDFEnvelopeWrap, bases<Attributes>, noncopyable>
-        pdfenvelope("PDFEnvelope", doc_PDFEnvelope);
+    nb::class_<PDFEnvelope, Attributes, PDFEnvelopeWrap>
+        pdfenvelope(m, "PDFEnvelope", nb::dynamic_attr(), doc_PDFEnvelope);
     wrap_registry_methods(pdfenvelope)
+        .def(nb::init<>())
         .def("__call__", callnparray,
-                bp::arg("r_array"))
+                nb::arg("r_array"))
         .def("__call__", &PDFEnvelope::operator(),
-                bp::arg("r"), doc_PDFEnvelope___call__)
-        .def_pickle(SerializationPickleSuite<PDFEnvelope,DICT_PICKLE>())
+                nb::arg("r"), doc_PDFEnvelope___call__)
         ;
+        SerializationPickleSuite<PDFEnvelope, DICT_PICKLE>::bind(pdfenvelope);
 
-    register_ptr_to_python<PDFEnvelopePtr>();
-
-    class_<QResolutionEnvelope, bases<PDFEnvelope> >(
-            "QResolutionEnvelope", doc_QResolutionEnvelope)
-        .def_pickle(SerializationPickleSuite<QResolutionEnvelope>())
+    nb::class_<QResolutionEnvelope, PDFEnvelope> qresenvelope(m,
+            "QResolutionEnvelope", doc_QResolutionEnvelope);
+    qresenvelope
+        .def(nb::init<>())
         ;
-    class_<ScaleEnvelope, bases<PDFEnvelope> >(
-            "ScaleEnvelope", doc_ScaleEnvelope)
-        .def_pickle(SerializationPickleSuite<ScaleEnvelope>())
+        SerializationPickleSuite<QResolutionEnvelope, DICT_PICKLE>::bind(qresenvelope);
+    nb::class_<ScaleEnvelope, PDFEnvelope> scaleenvelope(m,
+            "ScaleEnvelope", doc_ScaleEnvelope);
+    scaleenvelope
+        .def(nb::init<>())
         ;
-    class_<SphericalShapeEnvelope, bases<PDFEnvelope> >(
-            "SphericalShapeEnvelope", doc_SphericalShapeEnvelope)
-        .def_pickle(SerializationPickleSuite<SphericalShapeEnvelope>())
+        SerializationPickleSuite<ScaleEnvelope, DICT_PICKLE>::bind(scaleenvelope);
+    nb::class_<SphericalShapeEnvelope, PDFEnvelope> sphshapeenvelope(m,
+            "SphericalShapeEnvelope", doc_SphericalShapeEnvelope);
+    sphshapeenvelope
+        .def(nb::init<>())
         ;
-    class_<StepCutEnvelope, bases<PDFEnvelope> >(
-            "StepCutEnvelope", doc_StepCutEnvelope)
-        .def_pickle(SerializationPickleSuite<StepCutEnvelope>())
+        SerializationPickleSuite<SphericalShapeEnvelope, DICT_PICKLE>::bind(sphshapeenvelope);
+    nb::class_<StepCutEnvelope, PDFEnvelope> stepcutenvelope(m,
+            "StepCutEnvelope", doc_StepCutEnvelope);
+    sphshapeenvelope
+        .def(nb::init<>())
         ;
+        SerializationPickleSuite<StepCutEnvelope, DICT_PICKLE>::bind(sphshapeenvelope);
 
 }
 

--- a/src/extensions/wrap_PDFEnvelope.cpp
+++ b/src/extensions/wrap_PDFEnvelope.cpp
@@ -232,10 +232,10 @@ void wrap_PDFEnvelope(nb::module_ &m)
         SerializationPickleSuite<SphericalShapeEnvelope, DICT_PICKLE>::bind(sphshapeenvelope);
     nb::class_<StepCutEnvelope, PDFEnvelope> stepcutenvelope(m,
             "StepCutEnvelope", doc_StepCutEnvelope);
-    sphshapeenvelope
+    stepcutenvelope
         .def(nb::init<>())
         ;
-        SerializationPickleSuite<StepCutEnvelope, DICT_PICKLE>::bind(sphshapeenvelope);
+        SerializationPickleSuite<StepCutEnvelope, DICT_PICKLE>::bind(stepcutenvelope);
 
 }
 

--- a/src/extensions/wrap_PDFEnvelope.cpp
+++ b/src/extensions/wrap_PDFEnvelope.cpp
@@ -91,7 +91,8 @@ Returns   0 when x > stepcut.\n\
 // Helper class allows overload of the PDFEnvelope methods from Python.
 
 class PDFEnvelopeWrap :
-    public PDFEnvelope
+    public PDFEnvelope,
+    public PythonTrampolineTag
 {
     public:
 
@@ -210,32 +211,35 @@ void wrap_PDFEnvelope(nb::module_ &m)
         .def("__call__", &PDFEnvelope::operator(),
                 nb::arg("r"), doc_PDFEnvelope___call__)
         ;
-        SerializationPickleSuite<PDFEnvelope, DICT_PICKLE>::bind(pdfenvelope);
+        SerializationPickleSuite<
+            PDFEnvelope,
+            DICT_PICKLE,
+            PDFEnvelopeWrap>::bind(pdfenvelope);
 
     nb::class_<QResolutionEnvelope, PDFEnvelope> qresenvelope(m,
             "QResolutionEnvelope", doc_QResolutionEnvelope);
     qresenvelope
         .def(nb::init<>())
         ;
-        SerializationPickleSuite<QResolutionEnvelope, DICT_PICKLE>::bind(qresenvelope);
+        SerializationPickleSuite<QResolutionEnvelope, DICT_IGNORE>::bind(qresenvelope);
     nb::class_<ScaleEnvelope, PDFEnvelope> scaleenvelope(m,
             "ScaleEnvelope", doc_ScaleEnvelope);
     scaleenvelope
         .def(nb::init<>())
         ;
-        SerializationPickleSuite<ScaleEnvelope, DICT_PICKLE>::bind(scaleenvelope);
+        SerializationPickleSuite<ScaleEnvelope, DICT_IGNORE>::bind(scaleenvelope);
     nb::class_<SphericalShapeEnvelope, PDFEnvelope> sphshapeenvelope(m,
             "SphericalShapeEnvelope", doc_SphericalShapeEnvelope);
     sphshapeenvelope
         .def(nb::init<>())
         ;
-        SerializationPickleSuite<SphericalShapeEnvelope, DICT_PICKLE>::bind(sphshapeenvelope);
+        SerializationPickleSuite<SphericalShapeEnvelope, DICT_IGNORE>::bind(sphshapeenvelope);
     nb::class_<StepCutEnvelope, PDFEnvelope> stepcutenvelope(m,
             "StepCutEnvelope", doc_StepCutEnvelope);
     stepcutenvelope
         .def(nb::init<>())
         ;
-        SerializationPickleSuite<StepCutEnvelope, DICT_PICKLE>::bind(stepcutenvelope);
+        SerializationPickleSuite<StepCutEnvelope, DICT_IGNORE>::bind(stepcutenvelope);
 
 }
 

--- a/src/extensions/wrap_PDFEnvelope.cpp
+++ b/src/extensions/wrap_PDFEnvelope.cpp
@@ -105,7 +105,7 @@ class PDFEnvelopeWrap :
             nb::gil_scoped_acquire gil;
             nb::detail::ticket ticket(nb_trampoline, "create", true);
 
-            if (!ticket.key.is_valid()) 
+            if (!ticket.key.is_valid())
             {
                 throw nb::type_error(
                     "pure virtual method PDFEnvelope.create() called"
@@ -126,7 +126,7 @@ class PDFEnvelopeWrap :
             nb::gil_scoped_acquire gil;
             nb::detail::ticket ticket(nb_trampoline, "type", true);
 
-            if (!ticket.key.is_valid()) 
+            if (!ticket.key.is_valid())
             {
                 throw nb::type_error(
                     "pure virtual method PDFEnvelope.type() called"
@@ -145,7 +145,7 @@ class PDFEnvelopeWrap :
             nb::gil_scoped_acquire gil;
             nb::detail::ticket ticket(nb_trampoline, "__call__", true);
 
-            if (!ticket.key.is_valid()) 
+            if (!ticket.key.is_valid())
             {
                 throw nb::type_error(
                     "pure virtual method PDFEnvelope.__call__() called"

--- a/src/extensions/wrap_PairQuantity.cpp
+++ b/src/extensions/wrap_PairQuantity.cpp
@@ -334,12 +334,13 @@ inline nb::bytes string_to_pybytes(const std::string &s)
 // representation of QuantityType objects
 nb::object repr_QuantityType(const QuantityType& v)
 {
-    nb::tuple t = nb::make_tuple(v.size());
+    nb::list values;
 
     for (size_t i = 0; i < v.size(); ++i) {
-        t[i] = nb::cast(v[i]);
+        values.append(v[i]);
     }
 
+    nb::object t = nb::module_::import_("builtins").attr("tuple")(values);
     return nb::str("QuantityType{}").attr("format")(nb::repr(t));
 }
 

--- a/src/extensions/wrap_PairQuantity.cpp
+++ b/src/extensions/wrap_PairQuantity.cpp
@@ -32,6 +32,7 @@
 #include <nanobind/nanobind.h>
 #include <nanobind/trampoline.h>
 #include <nanobind/stl/bind_vector.h>
+#include <nanobind/stl/vector.h>
 
 #include <cstdlib>
 
@@ -716,7 +717,6 @@ void wrap_PairQuantity(nb::module_& m)
 {
     using namespace nswrap_PairQuantity;
     using diffpy::Attributes;
-    const nb::object None;
 
     typedef StructureAdapterPtr&(PairQuantity::*getstru)();
 
@@ -727,7 +727,7 @@ void wrap_PairQuantity(nb::module_& m)
         basepq(m, "BasePairQuantity");
     basepq
         .def(nb::init<>())
-        .def("eval", eval_asarray, nb::arg("stru")=None,
+        .def("eval", eval_asarray, nb::arg("stru")=nb::none(),
                 doc_BasePairQuantity_eval)
         .def_prop_ro("value", value_asarray<PairQuantity>,
                 doc_BasePairQuantity_value)
@@ -760,14 +760,14 @@ void wrap_PairQuantity(nb::module_& m)
                 doc_BasePairQuantity_invertMask)
         .def("setPairMask", set_pair_mask,
                 nb::arg("i"), nb::arg("j"), nb::arg("mask"),
-                 nb::arg("others")=None,
+                 nb::arg("others")=nb::none(),
                 doc_BasePairQuantity_setPairMask)
         .def("getPairMask", &PairQuantity::getPairMask,
                 nb::arg("i"), nb::arg("j"),
                 doc_BasePairQuantity_getPairMask)
         .def("setTypeMask", set_type_mask,
                 nb::arg("tpi"), nb::arg("tpj"), nb::arg("mask"),
-                 nb::arg("others")=None,
+                 nb::arg("others")=nb::none(),
                 doc_BasePairQuantity_setTypeMask)
         .def("getTypeMask", &PairQuantity::getTypeMask,
                 nb::arg("tpi"), nb::arg("tpj"),

--- a/src/extensions/wrap_PairQuantity.cpp
+++ b/src/extensions/wrap_PairQuantity.cpp
@@ -327,10 +327,20 @@ Reference to the internal vector of total contributions.\n\
 
 // wrappers ------------------------------------------------------------------
 
-inline nb::bytes string_to_pybytes(const std::string &s) 
+inline nb::bytes to_bytes(const std::string &s)
 {
     return nb::bytes(s.data(), s.size());
 }
+
+
+inline std::string from_bytes(nb::bytes b)
+{
+    return std::string(
+        static_cast<const char *>(b.data()),
+        b.size()
+    );
+}
+
 
 // representation of QuantityType objects
 nb::object repr_QuantityType(const QuantityType& v)
@@ -572,7 +582,8 @@ class PairQuantityExposed : public PairQuantity
 // methods from Python.
 
 class PairQuantityWrap :
-    public PairQuantityExposed
+    public PairQuantityExposed,
+    public PythonTrampolineTag
 {
     public:
 
@@ -582,7 +593,18 @@ class PairQuantityWrap :
 
         std::string getParallelData() const override
         {
-            NB_OVERRIDE_NAME("_getParallelData", getParallelData);
+            nb::gil_scoped_acquire gil;
+            nb::detail::ticket ticket(
+                nb_trampoline, "_getParallelData", false);
+
+            if (ticket.key.is_valid())
+            {
+                nb::object pdata =
+                    nb_trampoline.base().attr(ticket.key)();
+                return from_bytes(nb::cast<nb::bytes>(pdata));
+            }
+
+            return this->PairQuantityExposed::getParallelData();
         }
 
         std::string default_getParallelData() const
@@ -666,7 +688,17 @@ class PairQuantityWrap :
 
         void executeParallelMerge(const std::string& pdata) override
         {
-            NB_OVERRIDE_NAME("_executeParallelMerge", executeParallelMerge, pdata);
+            nb::gil_scoped_acquire gil;
+            nb::detail::ticket ticket(
+                nb_trampoline, "_executeParallelMerge", false);
+
+            if (ticket.key.is_valid())
+            {
+                nb_trampoline.base().attr(ticket.key)(to_bytes(pdata));
+                return;
+            }
+
+            this->PairQuantityExposed::executeParallelMerge(pdata);
         }
 
         void default_executeParallelMerge(const std::string& pdata)
@@ -731,10 +763,18 @@ void wrap_PairQuantity(nb::module_& m)
                 doc_BasePairQuantity_eval)
         .def_prop_ro("value", value_asarray<PairQuantity>,
                 doc_BasePairQuantity_value)
-        .def("_mergeParallelData", &PairQuantity::mergeParallelData,
+        .def("_mergeParallelData",
+                [](PairQuantity &pq, nb::bytes pdata, int ncpu)
+                {
+                    pq.mergeParallelData(from_bytes(pdata), ncpu);
+                },
                 nb::arg("pdata"), nb::arg("ncpu"),
                 doc_BasePairQuantity__mergeParallelData)
-        .def("_getParallelData", &PairQuantity::getParallelData,
+        .def("_getParallelData",
+                [](const PairQuantity &pq)
+                {
+                    return to_bytes(pq.getParallelData());
+                },
                 doc_BasePairQuantity__getParallelData)
         .def("setStructure", [](PairQuantity &pq, nb::object stru) 
                 {
@@ -788,7 +828,7 @@ void wrap_PairQuantity(nb::module_& m)
                 doc_PairQuantity_ticker)
         .def("_getParallelData", [](const PairQuantityExposed &pq) 
                 {
-                    return string_to_pybytes(pq.getParallelData());
+                    return to_bytes(pq.getParallelData());
                 },
                 doc_PairQuantity__getParallelData)
         .def("_resizeValue",
@@ -807,7 +847,10 @@ void wrap_PairQuantity(nb::module_& m)
                 nb::arg("bnds"), nb::arg("sumscale"),
                 doc_PairQuantity__addPairContribution)
         .def("_executeParallelMerge",
-                &PairQuantityExposed::executeParallelMerge,
+                [](PairQuantityExposed &pq, nb::bytes pdata)
+                {
+                    pq.executeParallelMerge(from_bytes(pdata));
+                },
                 nb::arg("pdata"),
                 doc_PairQuantity__executeParallelMerge)
         .def("_finishValue",
@@ -828,7 +871,10 @@ void wrap_PairQuantity(nb::module_& m)
         ;
         // classes PairQuantityExposed, PairQuantityWrap add no members,
         // therefore we can create pickle suite from C++ base class.
-        PairQuantityPickleSuite<PairQuantity, DICT_PICKLE>::bind(pq);
+        PairQuantityPickleSuite<
+            PairQuantity,
+            DICT_PICKLE,
+            PairQuantityExposed>::bind(pq);
 
 }
 

--- a/src/extensions/wrap_PairQuantity.cpp
+++ b/src/extensions/wrap_PairQuantity.cpp
@@ -726,6 +726,7 @@ void wrap_PairQuantity(nb::module_& m)
     nb::class_<PairQuantity, Attributes>
         basepq(m, "BasePairQuantity");
     basepq
+        .def(nb::init<>())
         .def("eval", eval_asarray, nb::arg("stru")=None,
                 doc_BasePairQuantity_eval)
         .def_prop_ro("value", value_asarray<PairQuantity>,
@@ -780,6 +781,7 @@ void wrap_PairQuantity(nb::module_& m)
 
     nb::class_<PairQuantityExposed, PairQuantity, PairQuantityWrap> pq(m, "PairQuantity", doc_PairQuantity);
     pq
+        .def(nb::init<>())
         .def("ticker",
                 &PairQuantityExposed::ticker,
                 nb::rv_policy::reference_internal,

--- a/src/extensions/wrap_PairQuantity.cpp
+++ b/src/extensions/wrap_PairQuantity.cpp
@@ -29,11 +29,9 @@
 *
 *****************************************************************************/
 
-#include <boost/python/class.hpp>
-#include <boost/python/suite/indexing/vector_indexing_suite.hpp>
-#include <boost/python/stl_iterator.hpp>
-#include <boost/python/copy_non_const_reference.hpp>
-#include <boost/python/return_internal_reference.hpp>
+#include <nanobind/nanobind.h>
+#include <nanobind/trampoline.h>
+#include <nanobind/stl/bind_vector.h>
 
 #include <cstdlib>
 
@@ -42,47 +40,14 @@
 #include "srreal_validators.hpp"
 
 #include <diffpy/srreal/PairQuantity.hpp>
+#include <type_traits>
 
-namespace boost {
-namespace python {
-
-struct make_pybytes
-{
-    PyObject* operator()(const std::string& s) const
-    {
-        std::string::const_pointer pfirst = s.empty() ? NULL : &(s[0]);
-        PyObject* rv = PyBytes_FromStringAndSize(pfirst, s.size());
-        return rv;
-    }
-
-
-    const PyTypeObject* get_pytype() const
-    {
-        return &PyBytes_Type;
-    }
-};
-
-
-struct copy_string_to_pybytes
-{
-    template <typename T>
-    struct apply
-    {
-        // Fail if this result conversion is used for function
-        // that does not return std::string.
-        BOOST_MPL_ASSERT(( is_same<T, std::string> ));
-        typedef make_pybytes type;
-    };
-};
-
-}   // namespace python
-}   // namespace boost
+namespace nb = nanobind;
+NB_MAKE_OPAQUE(diffpy::srreal::QuantityType);
 
 namespace srrealmodule {
 namespace nswrap_PairQuantity {
 
-using namespace boost;
-using namespace boost::python;
 using namespace diffpy::srreal;
 
 // docstrings ----------------------------------------------------------------
@@ -361,22 +326,31 @@ Reference to the internal vector of total contributions.\n\
 
 // wrappers ------------------------------------------------------------------
 
-// representation of QuantityType objects
-python::object repr_QuantityType(const QuantityType& v)
+inline nb::bytes string_to_pybytes(const std::string &s) 
 {
-    python::object rv = ("QuantityType%r" %
-        python::make_tuple(python::tuple(v)));
-    return rv;
+    return nb::bytes(s.data(), s.size());
+}
+
+// representation of QuantityType objects
+nb::object repr_QuantityType(const QuantityType& v)
+{
+    nb::tuple t = nb::make_tuple(v.size());
+
+    for (size_t i = 0; i < v.size(); ++i) {
+        t[i] = nb::cast(v[i]);
+    }
+
+    return nb::str("QuantityType{}").attr("format")(nb::repr(t));
 }
 
 
 // PairQuantity::eval is a template non-constant method and
 // needs an explicit wrapper function.
 
-python::object eval_asarray(PairQuantity& obj, python::object& a)
+nb::object eval_asarray(PairQuantity& obj, nb::object& a)
 {
     QuantityType value = (a.is_none()) ? obj.eval() : obj.eval(a);
-    python::object rv = convertToNumPyArray(value);
+    nb::object rv = convertToNumPyArray(value);
     return rv;
 }
 
@@ -400,10 +374,9 @@ std::string stringevaluatortype(PQEvaluatorType tp)
         case CHECK:
             return evtp_CHECK;
     }
-    const char* emsg = "Unknown internal value of PQEvaluatorType.";
-    PyErr_SetString(PyExc_NotImplementedError, emsg);
-    throw_error_already_set();
-    abort();
+    PyErr_SetString(PyExc_NotImplementedError,
+                    "Unknown internal value of PQEvaluatorType.");
+    throw nb::python_error();
 }
 
 
@@ -418,11 +391,10 @@ void setevaluatortype(PairQuantity& pq, const std::string& tp)
     if (tp == evtp_BASIC)  return pq.setEvaluatorType(BASIC);
     if (tp == evtp_OPTIMIZED)  return pq.setEvaluatorType(OPTIMIZED);
     if (tp == evtp_CHECK)  return pq.setEvaluatorType(CHECK);
-    python::object emsg = ("evaluatortype must be one of %r." %
-            python::make_tuple(python::make_tuple(
-                    evtp_BASIC, evtp_OPTIMIZED, evtp_CHECK)));
-    PyErr_SetObject(PyExc_ValueError, emsg.ptr());
-    throw_error_already_set();
+
+    throw nb::value_error(
+        "evaluatortype must be one of ('BASIC', 'OPTIMIZED', 'CHECK')."
+    );
 }
 
 // support for the evaluatortypeused read-only property
@@ -434,22 +406,19 @@ std::string getevaluatortypeused(const PairQuantity& obj)
 
 // support "all", "ALL" and integer iterables in setPairMask
 
-std::vector<int> parsepairindex(python::object i)
+std::vector<int> parsepairindex(nb::object i)
 {
     std::vector<int> rv;
     // string equal "all" or "ALL"
-    python::extract<std::string> gets(i);
-    if (gets.check())
+    if (nb::isinstance<nb::str>(i)) 
     {
-        python::str lc_all(PairQuantity::ALLATOMSSTR);
-        python::str uc_all = lc_all.upper();
-        if (i != lc_all && i != uc_all)
+        std::string s = nb::cast<std::string>(i);
+
+        if (s != PairQuantity::ALLATOMSSTR && s != "ALL") 
         {
-            python::object emsg = ("String argument must be %r or %r." %
-                 python::make_tuple(lc_all, uc_all));
-            PyErr_SetObject(PyExc_ValueError, emsg.ptr());
-            throw_error_already_set();
+            throw nb::value_error("String argument must be 'all' or 'ALL'.");
         }
+
         rv.push_back(PairQuantity::ALLATOMSINT);
         return rv;
     }
@@ -460,36 +429,29 @@ std::vector<int> parsepairindex(python::object i)
 
 // support string iterables in setTypeMask
 
-std::vector<std::string> parsepairtypes(
-        python::extract<std::string>& getsmbli, python::object smbli)
+std::vector<std::string> parsepairtypes(nb::object smbl)
 {
-    std::vector<std::string> rv;
-    if (getsmbli.check())
+    if (nb::isinstance<nb::str>(smbl)) 
     {
-        rv.push_back(getsmbli());
+        return { nb::cast<std::string>(smbl) };
     }
-    else
-    {
-        python::stl_input_iterator<std::string> first(smbli), last;
-        rv.assign(first, last);
-    }
-    return rv;
+
+    return nb::cast<std::vector<std::string>>(smbl);
 }
 
 
-void mask_all_pairs(PairQuantity& obj, python::object msk)
+void mask_all_pairs(PairQuantity& obj, nb::object msk)
 {
-    bool mask = msk;
-    obj.maskAllPairs(mask);
+    obj.maskAllPairs(nb::cast<bool>(msk));
 }
 
 
 void set_pair_mask(PairQuantity& obj,
-        python::object i, python::object j, python::object msk,
-        python::object others)
+        nb::object i, nb::object j, nb::object msk,
+        nb::object others)
 {
     if (!others.is_none())  mask_all_pairs(obj, others);
-    bool mask = msk;
+    bool mask = nb::cast<bool>(msk);
     // short circuit for normal call with scalar values
     if (!isiterable(i) && !isiterable(j))
     {
@@ -512,28 +474,22 @@ void set_pair_mask(PairQuantity& obj,
 
 
 void set_type_mask(PairQuantity& obj,
-        python::object smbli, python::object smblj, python::object msk,
-        python::object others)
+        nb::object smbli, nb::object smblj, nb::object msk,
+        nb::object others)
 {
     using namespace std;
     if (!others.is_none())  mask_all_pairs(obj, others);
-    python::extract<string> getsmbli(smbli);
-    python::extract<string> getsmblj(smblj);
-    bool mask = msk;
-    // short circuit for normal call
-    if (getsmbli.check() && getsmblj.check())
-    {
-        obj.setTypeMask(getsmbli(), getsmblj(), mask);
-        return;
-    }
-    vector<string> isymbols = parsepairtypes(getsmbli, smbli);
-    vector<string> jsymbols = parsepairtypes(getsmblj, smblj);
+
+    bool mask = nb::cast<bool>(msk);
+
+    std::vector<std::string> isymbols = parsepairtypes(smbli);
+    std::vector<std::string> jsymbols = parsepairtypes(smblj);
     vector<string>::const_iterator tii, tjj;
-    for (tii = isymbols.begin(); tii != isymbols.end(); ++tii)
+    for (const std::string &ti : isymbols) 
     {
-        for (tjj = jsymbols.begin(); tjj != jsymbols.end(); ++tjj)
+        for (const std::string &tj : jsymbols) 
         {
-            obj.setTypeMask(*tii, *tjj, mask);
+            obj.setTypeMask(ti, tj, mask);
         }
     }
 }
@@ -541,11 +497,10 @@ void set_type_mask(PairQuantity& obj,
 
 // provide a copy method for convenient deepcopy of the object
 
-python::object pqcopy(python::object pqobj)
+nb::object pqcopy(nb::object pqobj)
 {
-    python::object copy = python::import("copy").attr("copy");
-    python::object rv = copy(pqobj);
-    return rv;
+    nb::object copy = nb::module_::import_("copy").attr("copy");
+    return copy(pqobj);
 }
 
 // Helper C++ class for publicizing the protected methods.
@@ -615,18 +570,17 @@ class PairQuantityExposed : public PairQuantity
 // methods from Python.
 
 class PairQuantityWrap :
-    public PairQuantityExposed,
-    public wrapper<PairQuantityExposed>
+    public PairQuantityExposed
 {
     public:
 
+        NB_TRAMPOLINE(PairQuantityExposed, 10);
+
         // Make getParallelData overridable from Python.
 
-        std::string getParallelData() const
+        std::string getParallelData() const override
         {
-            override f = this->get_override("_getParallelData");
-            if (f)  return f();
-            return this->default_getParallelData();
+            NB_OVERRIDE_NAME("_getParallelData", getParallelData);
         }
 
         std::string default_getParallelData() const
@@ -636,16 +590,18 @@ class PairQuantityWrap :
 
         // Make the ticker method overridable from Python
 
-        diffpy::eventticker::EventTicker& ticker() const
+        diffpy::eventticker::EventTicker& ticker() const override
         {
             using diffpy::eventticker::EventTicker;
-            override f = this->get_override("ticker");
-            if (f)
+            nb::gil_scoped_acquire gil;
+            nb::detail::ticket ticket(nb_trampoline, "ticker", false);
+
+            if (ticket.key.is_valid()) 
             {
-                // avoid "dangling reference error" when used from C++
-                object ptic = f();
-                return extract<EventTicker&>(ptic);
+                nb::object ptic = nb_trampoline.base().attr(ticket.key)();
+                return nb::cast<EventTicker &>(ptic);
             }
+
             return this->default_ticker();
         }
 
@@ -657,11 +613,9 @@ class PairQuantityWrap :
         // Make the protected virtual methods public so they
         // can be exported to Python and overridden as well.
 
-        void resizeValue(size_t sz)
+        void resizeValue(size_t sz) override
         {
-            override f = this->get_override("_resizeValue");
-            if (f)  f(sz);
-            else    this->default_resizeValue(sz);
+            NB_OVERRIDE_NAME("_resizeValue", resizeValue, sz);
         }
 
         void default_resizeValue(size_t sz)
@@ -670,11 +624,9 @@ class PairQuantityWrap :
         }
 
 
-        void resetValue()
+        void resetValue() override
         {
-            override f = this->get_override("_resetValue");
-            if (f)  f();
-            else    this->default_resetValue();
+            NB_OVERRIDE_NAME("_resetValue", resetValue);
         }
 
         void default_resetValue()
@@ -683,11 +635,9 @@ class PairQuantityWrap :
         }
 
 
-        void configureBondGenerator(BaseBondGenerator& bnds) const
+        void configureBondGenerator(BaseBondGenerator& bnds) const override
         {
-            override f = this->get_override("_configureBondGenerator");
-            if (f)  f(ptr(&bnds));
-            else    this->default_configureBondGenerator(bnds);
+            NB_OVERRIDE_NAME("_configureBondGenerator", configureBondGenerator, bnds);
         }
 
         void default_configureBondGenerator(BaseBondGenerator& bnds) const
@@ -697,11 +647,12 @@ class PairQuantityWrap :
 
 
         void addPairContribution(const BaseBondGenerator& bnds,
-                int summationscale)
+                int summationscale) override
         {
-            override f = this->get_override("_addPairContribution");
-            if (f)  f(ptr(&bnds), summationscale);
-            else    this->default_addPairContribution(bnds, summationscale);
+            NB_OVERRIDE_NAME("_addPairContribution",
+                            addPairContribution,
+                            bnds,
+                            summationscale);
         }
 
         void default_addPairContribution(const BaseBondGenerator& bnds,
@@ -711,11 +662,9 @@ class PairQuantityWrap :
         }
 
 
-        void executeParallelMerge(const std::string& pdata)
+        void executeParallelMerge(const std::string& pdata) override
         {
-            override f = this->get_override("_executeParallelMerge");
-            if (f)  f(pdata);
-            else    this->default_executeParallelMerge(pdata);
+            NB_OVERRIDE_NAME("_executeParallelMerge", executeParallelMerge, pdata);
         }
 
         void default_executeParallelMerge(const std::string& pdata)
@@ -724,11 +673,9 @@ class PairQuantityWrap :
         }
 
 
-        void finishValue()
+        void finishValue() override
         {
-            override f = this->get_override("_finishValue");
-            if (f)  f();
-            else    this->default_finishValue();
+        NB_OVERRIDE_NAME("_finishValue", finishValue);
         }
 
         void default_finishValue()
@@ -737,11 +684,9 @@ class PairQuantityWrap :
         }
 
 
-        void stashPartialValue()
+        void stashPartialValue() override
         {
-            override f = this->get_override("_stashPartialValue");
-            if (f)  f();
-            else    this->default_stashPartialValue();
+            NB_OVERRIDE_NAME("_stashPartialValue", stashPartialValue);
         }
 
         void default_stashPartialValue()
@@ -750,11 +695,9 @@ class PairQuantityWrap :
         }
 
 
-        void restorePartialValue()
+        void restorePartialValue() override
         {
-            override f = this->get_override("_restorePartialValue");
-            if (f)  f();
-            else    this->default_restorePartialValue();
+            NB_OVERRIDE_NAME("_restorePartialValue", restorePartialValue);
         }
 
         void default_restorePartialValue()
@@ -768,126 +711,121 @@ class PairQuantityWrap :
 
 // Wrapper definition --------------------------------------------------------
 
-void wrap_PairQuantity()
+void wrap_PairQuantity(nb::module_& m)
 {
     using namespace nswrap_PairQuantity;
     using diffpy::Attributes;
-    const python::object None;
+    const nb::object None;
 
     typedef StructureAdapterPtr&(PairQuantity::*getstru)();
 
-    class_<QuantityType>("QuantityType")
-        .def(vector_indexing_suite<QuantityType>())
-        .def("__repr__", repr_QuantityType)
-        ;
+    nb::bind_vector<QuantityType>(m, "QuantityType")
+        .def("__repr__", &repr_QuantityType);
 
-    class_<PairQuantity, bases<Attributes> >("BasePairQuantity")
-        .def("eval", eval_asarray, python::arg("stru")=None,
+    nb::class_<PairQuantity, Attributes>
+        basepq(m, "BasePairQuantity");
+    basepq
+        .def("eval", eval_asarray, nb::arg("stru")=None,
                 doc_BasePairQuantity_eval)
-        .add_property("value", value_asarray<PairQuantity>,
+        .def_prop_ro("value", value_asarray<PairQuantity>,
                 doc_BasePairQuantity_value)
         .def("_mergeParallelData", &PairQuantity::mergeParallelData,
-                (python::arg("pdata"), python::arg("ncpu")),
+                nb::arg("pdata"), nb::arg("ncpu"),
                 doc_BasePairQuantity__mergeParallelData)
         .def("_getParallelData", &PairQuantity::getParallelData,
-                return_value_policy<copy_string_to_pybytes>(),
                 doc_BasePairQuantity__getParallelData)
-        .def("setStructure", &PairQuantity::setStructure<object>,
-                python::arg("stru"),
+        .def("setStructure", [](PairQuantity &pq, nb::object stru) 
+                {
+                    pq.setStructure(stru);
+                },
+                nb::arg("stru"),
                 doc_BasePairQuantity_setStructure)
         .def("getStructure", getstru(&PairQuantity::getStructure),
-                return_value_policy<copy_non_const_reference>(),
                 doc_BasePairQuantity_getStructure)
         .def("_setupParallelRun", &PairQuantity::setupParallelRun,
-                (python::arg("cpuindex"), python::arg("ncpu")),
+                nb::arg("cpuindex"), nb::arg("ncpu"),
                 doc_BasePairQuantity__setupParallelRun)
-        .add_property("evaluatortype",
+        .def_prop_rw("evaluatortype",
                 getevaluatortype, setevaluatortype,
                 doc_BasePairQuantity_evaluatortype)
-        .add_property("evaluatortypeused",
+        .def_prop_ro("evaluatortypeused",
                 getevaluatortypeused,
                 doc_BasePairQuantity_evaluatortypeused)
         .def("maskAllPairs", mask_all_pairs,
-                python::arg("mask"),
+                nb::arg("mask"),
                 doc_BasePairQuantity_maskAllPairs)
         .def("invertMask", &PairQuantity::invertMask,
                 doc_BasePairQuantity_invertMask)
         .def("setPairMask", set_pair_mask,
-                (python::arg("i"), python::arg("j"), python::arg("mask"),
-                 python::arg("others")=None),
+                nb::arg("i"), nb::arg("j"), nb::arg("mask"),
+                 nb::arg("others")=None,
                 doc_BasePairQuantity_setPairMask)
         .def("getPairMask", &PairQuantity::getPairMask,
-                (python::arg("i"), python::arg("j")),
+                nb::arg("i"), nb::arg("j"),
                 doc_BasePairQuantity_getPairMask)
         .def("setTypeMask", set_type_mask,
-                (python::arg("tpi"), python::arg("tpj"), python::arg("mask"),
-                 python::arg("others")=None),
+                nb::arg("tpi"), nb::arg("tpj"), nb::arg("mask"),
+                 nb::arg("others")=None,
                 doc_BasePairQuantity_setTypeMask)
         .def("getTypeMask", &PairQuantity::getTypeMask,
-                (python::arg("tpi"), python::arg("tpj")),
+                nb::arg("tpi"), nb::arg("tpj"),
                 doc_BasePairQuantity_getTypeMask)
         .def("ticker", &PairQuantity::ticker,
-                return_internal_reference<>(),
+                nb::rv_policy::reference_internal,
                 doc_BasePairQuantity_ticker)
         .def("copy", pqcopy,
                 doc_BasePairQuantity_copy)
         ;
 
-    class_<PairQuantityWrap, bases<PairQuantity>,
-        noncopyable>("PairQuantity", doc_PairQuantity)
+    nb::class_<PairQuantityExposed, PairQuantity, PairQuantityWrap> pq(m, "PairQuantity", doc_PairQuantity);
+    pq
         .def("ticker",
                 &PairQuantityExposed::ticker,
-                &PairQuantityWrap::default_ticker,
-                return_internal_reference<>(),
+                nb::rv_policy::reference_internal,
                 doc_PairQuantity_ticker)
-        .def("_getParallelData",
-                &PairQuantityExposed::getParallelData,
-                &PairQuantityWrap::default_getParallelData,
-                return_value_policy<copy_string_to_pybytes>(),
+        .def("_getParallelData", [](const PairQuantityExposed &pq) 
+                {
+                    return string_to_pybytes(pq.getParallelData());
+                },
                 doc_PairQuantity__getParallelData)
         .def("_resizeValue",
                 &PairQuantityExposed::resizeValue,
-                &PairQuantityWrap::default_resizeValue,
-                python::arg("sz"),
+                nb::arg("sz"),
                 doc_PairQuantity__resizeValue)
         .def("_resetValue",
                 &PairQuantityExposed::resetValue,
-                &PairQuantityWrap::default_resetValue,
                 doc_PairQuantity__resetValue)
         .def("_configureBondGenerator",
                 &PairQuantityExposed::configureBondGenerator,
-                &PairQuantityWrap::default_configureBondGenerator,
-                python::arg("bnds"),
+                nb::arg("bnds"),
                 doc_PairQuantity__configureBondGenerator)
         .def("_addPairContribution",
                 &PairQuantityExposed::addPairContribution,
-                &PairQuantityWrap::default_addPairContribution,
-                (python::arg("bnds"), python::arg("sumscale")),
+                nb::arg("bnds"), nb::arg("sumscale"),
                 doc_PairQuantity__addPairContribution)
         .def("_executeParallelMerge",
                 &PairQuantityExposed::executeParallelMerge,
-                &PairQuantityWrap::default_executeParallelMerge,
-                python::arg("pdata"),
+                nb::arg("pdata"),
                 doc_PairQuantity__executeParallelMerge)
         .def("_finishValue",
                 &PairQuantityExposed::finishValue,
-                &PairQuantityWrap::default_finishValue,
                 doc_PairQuantity__finishValue)
         .def("_stashPartialValue",
                 &PairQuantityExposed::stashPartialValue,
-                &PairQuantityWrap::default_stashPartialValue,
                 doc_PairQuantity__stashPartialValue)
         .def("_restorePartialValue",
                 &PairQuantityExposed::restorePartialValue,
-                &PairQuantityWrap::default_restorePartialValue,
                 doc_PairQuantity__restorePartialValue)
-        .add_property("_value", make_function(&PairQuantityWrap::value,
-                    return_internal_reference<>()),
+        .def_prop_ro("_value", [](PairQuantityExposed &pq) -> QuantityType & 
+                {
+                    return pq.value();
+                },
+                nb::rv_policy::reference_internal,
                 doc_PairQuantity__value)
+        ;
         // classes PairQuantityExposed, PairQuantityWrap add no members,
         // therefore we can create pickle suite from C++ base class.
-        .def_pickle(PairQuantityPickleSuite<PairQuantity, DICT_PICKLE>())
-        ;
+        PairQuantityPickleSuite<PairQuantity, DICT_PICKLE>::bind(pq);
 
 }
 

--- a/src/extensions/wrap_PairQuantity.cpp
+++ b/src/extensions/wrap_PairQuantity.cpp
@@ -448,13 +448,42 @@ std::vector<std::string> parsepairtypes(nb::object smbl)
         return { nb::cast<std::string>(smbl) };
     }
 
-    return nb::cast<std::vector<std::string>>(smbl);
+    if (!isiterable(smbl))
+    {
+        PyErr_SetString(
+            PyExc_TypeError,
+            "atom type argument must be a string or iterable of strings");
+        throw nb::python_error();
+    }
+
+    std::vector<std::string> rv;
+    for (nb::handle item : smbl)
+    {
+        if (!nb::isinstance<nb::str>(item))
+        {
+            PyErr_SetString(
+                PyExc_TypeError,
+                "atom type iterable must contain strings");
+            throw nb::python_error();
+        }
+        rv.push_back(nb::cast<std::string>(item));
+    }
+    return rv;
+}
+
+
+bool extractbool(nb::object obj)
+{
+    int truth = PyObject_IsTrue(obj.ptr());
+    if (truth < 0)
+        nb::raise_python_error();
+    return truth != 0;
 }
 
 
 void mask_all_pairs(PairQuantity& obj, nb::object msk)
 {
-    obj.maskAllPairs(nb::cast<bool>(msk));
+    obj.maskAllPairs(extractbool(msk));
 }
 
 
@@ -463,7 +492,7 @@ void set_pair_mask(PairQuantity& obj,
         nb::object others)
 {
     if (!others.is_none())  mask_all_pairs(obj, others);
-    bool mask = nb::cast<bool>(msk);
+    bool mask = extractbool(msk);
     // short circuit for normal call with scalar values
     if (!isiterable(i) && !isiterable(j))
     {
@@ -492,7 +521,7 @@ void set_type_mask(PairQuantity& obj,
     using namespace std;
     if (!others.is_none())  mask_all_pairs(obj, others);
 
-    bool mask = nb::cast<bool>(msk);
+    bool mask = extractbool(msk);
 
     std::vector<std::string> isymbols = parsepairtypes(smbli);
     std::vector<std::string> jsymbols = parsepairtypes(smblj);
@@ -513,6 +542,20 @@ nb::object pqcopy(nb::object pqobj)
 {
     nb::object copy = nb::module_::import_("copy").attr("copy");
     return copy(pqobj);
+}
+
+
+nb::object borrowed_bond_generator(BaseBondGenerator& bnds)
+{
+    return nb::cast(&bnds, nb::rv_policy::reference);
+}
+
+
+nb::object borrowed_bond_generator(const BaseBondGenerator& bnds)
+{
+    return nb::cast(
+        const_cast<BaseBondGenerator*>(&bnds),
+        nb::rv_policy::reference);
 }
 
 // Helper C++ class for publicizing the protected methods.
@@ -661,7 +704,18 @@ class PairQuantityWrap :
 
         void configureBondGenerator(BaseBondGenerator& bnds) const override
         {
-            NB_OVERRIDE_NAME("_configureBondGenerator", configureBondGenerator, bnds);
+            nb::gil_scoped_acquire gil;
+            nb::detail::ticket ticket(
+                nb_trampoline, "_configureBondGenerator", false);
+
+            if (ticket.key.is_valid())
+            {
+                nb_trampoline.base().attr(ticket.key)(
+                    borrowed_bond_generator(bnds));
+                return;
+            }
+
+            this->default_configureBondGenerator(bnds);
         }
 
         void default_configureBondGenerator(BaseBondGenerator& bnds) const
@@ -673,10 +727,19 @@ class PairQuantityWrap :
         void addPairContribution(const BaseBondGenerator& bnds,
                 int summationscale) override
         {
-            NB_OVERRIDE_NAME("_addPairContribution",
-                            addPairContribution,
-                            bnds,
-                            summationscale);
+            nb::gil_scoped_acquire gil;
+            nb::detail::ticket ticket(
+                nb_trampoline, "_addPairContribution", false);
+
+            if (ticket.key.is_valid())
+            {
+                nb_trampoline.base().attr(ticket.key)(
+                    borrowed_bond_generator(bnds),
+                    summationscale);
+                return;
+            }
+
+            this->default_addPairContribution(bnds, summationscale);
         }
 
         void default_addPairContribution(const BaseBondGenerator& bnds,
@@ -756,7 +819,7 @@ void wrap_PairQuantity(nb::module_& m)
         .def("__repr__", &repr_QuantityType);
 
     nb::class_<PairQuantity, Attributes>
-        basepq(m, "BasePairQuantity");
+        basepq(m, "BasePairQuantity", nb::is_weak_referenceable());
     basepq
         .def(nb::init<>())
         .def("eval", eval_asarray, nb::arg("stru")=nb::none(),
@@ -817,11 +880,26 @@ void wrap_PairQuantity(nb::module_& m)
                 doc_BasePairQuantity_ticker)
         .def("copy", pqcopy,
                 doc_BasePairQuantity_copy)
+        .def("__reduce__", [](nb::object) -> nb::object 
+        {
+            throw std::runtime_error("cannot pickle BasePairQuantity object");
+        });
         ;
 
-    nb::class_<PairQuantityExposed, PairQuantity, PairQuantityWrap> pq(m, "PairQuantity", doc_PairQuantity);
+    nb::class_<PairQuantityExposed, PairQuantity, PairQuantityWrap> pq(
+            m, "PairQuantity",
+            nb::dynamic_attr(),
+            nb::is_weak_referenceable(),
+            doc_PairQuantity);
     pq
         .def(nb::init<>())
+        .def("ticker",
+                [](const PairQuantityExposed& obj)
+                    -> diffpy::eventticker::EventTicker&
+                {
+                    return obj.PairQuantity::ticker();
+                },
+                nb::rv_policy::reference_internal)
         .def("ticker",
                 &PairQuantityExposed::ticker,
                 nb::rv_policy::reference_internal,

--- a/src/extensions/wrap_PairQuantity.cpp
+++ b/src/extensions/wrap_PairQuantity.cpp
@@ -422,11 +422,11 @@ std::vector<int> parsepairindex(nb::object i)
 {
     std::vector<int> rv;
     // string equal "all" or "ALL"
-    if (nb::isinstance<nb::str>(i)) 
+    if (nb::isinstance<nb::str>(i))
     {
         std::string s = nb::cast<std::string>(i);
 
-        if (s != PairQuantity::ALLATOMSSTR && s != "ALL") 
+        if (s != PairQuantity::ALLATOMSSTR && s != "ALL")
         {
             throw nb::value_error("String argument must be 'all' or 'ALL'.");
         }
@@ -443,7 +443,7 @@ std::vector<int> parsepairindex(nb::object i)
 
 std::vector<std::string> parsepairtypes(nb::object smbl)
 {
-    if (nb::isinstance<nb::str>(smbl)) 
+    if (nb::isinstance<nb::str>(smbl))
     {
         return { nb::cast<std::string>(smbl) };
     }
@@ -526,9 +526,9 @@ void set_type_mask(PairQuantity& obj,
     std::vector<std::string> isymbols = parsepairtypes(smbli);
     std::vector<std::string> jsymbols = parsepairtypes(smblj);
     vector<string>::const_iterator tii, tjj;
-    for (const std::string &ti : isymbols) 
+    for (const std::string &ti : isymbols)
     {
-        for (const std::string &tj : jsymbols) 
+        for (const std::string &tj : jsymbols)
         {
             obj.setTypeMask(ti, tj, mask);
         }
@@ -663,7 +663,7 @@ class PairQuantityWrap :
             nb::gil_scoped_acquire gil;
             nb::detail::ticket ticket(nb_trampoline, "ticker", false);
 
-            if (ticket.key.is_valid()) 
+            if (ticket.key.is_valid())
             {
                 nb::object ptic = nb_trampoline.base().attr(ticket.key)();
                 return nb::cast<EventTicker &>(ptic);
@@ -839,7 +839,7 @@ void wrap_PairQuantity(nb::module_& m)
                     return to_bytes(pq.getParallelData());
                 },
                 doc_BasePairQuantity__getParallelData)
-        .def("setStructure", [](PairQuantity &pq, nb::object stru) 
+        .def("setStructure", [](PairQuantity &pq, nb::object stru)
                 {
                     pq.setStructure(stru);
                 },
@@ -880,7 +880,7 @@ void wrap_PairQuantity(nb::module_& m)
                 doc_BasePairQuantity_ticker)
         .def("copy", pqcopy,
                 doc_BasePairQuantity_copy)
-        .def("__reduce__", [](nb::object) -> nb::object 
+        .def("__reduce__", [](nb::object) -> nb::object
         {
             throw std::runtime_error("cannot pickle BasePairQuantity object");
         });
@@ -904,7 +904,7 @@ void wrap_PairQuantity(nb::module_& m)
                 &PairQuantityExposed::ticker,
                 nb::rv_policy::reference_internal,
                 doc_PairQuantity_ticker)
-        .def("_getParallelData", [](const PairQuantityExposed &pq) 
+        .def("_getParallelData", [](const PairQuantityExposed &pq)
                 {
                     return to_bytes(pq.getParallelData());
                 },
@@ -940,7 +940,7 @@ void wrap_PairQuantity(nb::module_& m)
         .def("_restorePartialValue",
                 &PairQuantityExposed::restorePartialValue,
                 doc_PairQuantity__restorePartialValue)
-        .def_prop_ro("_value", [](PairQuantityExposed &pq) -> QuantityType & 
+        .def_prop_ro("_value", [](PairQuantityExposed &pq) -> QuantityType &
                 {
                     return pq.value();
                 },

--- a/src/extensions/wrap_PeakProfile.cpp
+++ b/src/extensions/wrap_PeakProfile.cpp
@@ -106,7 +106,8 @@ The profile is also rescaled to keep the integrated area of 1.\n\
 // Support for override of PeakProfile methods from Python.
 
 class PeakProfileWrap :
-    public PeakProfile
+    public PeakProfile,
+    public PythonTrampolineTag
 {
     public:
 
@@ -242,7 +243,10 @@ void wrap_PeakProfile(nb::module_& m)
                 doc_PeakProfile_ticker)
         ;
 
-    SerializationPickleSuite<PeakProfile, DICT_PICKLE>::bind(peakprofile);
+    SerializationPickleSuite<
+        PeakProfile,
+        DICT_PICKLE,
+        PeakProfileWrap>::bind(peakprofile);
 
     nb::class_<GaussianProfile, PeakProfile> gaussianprofile(m,
             "GaussianProfile", doc_GaussianProfile);

--- a/src/extensions/wrap_PeakProfile.cpp
+++ b/src/extensions/wrap_PeakProfile.cpp
@@ -17,10 +17,8 @@
 *
 *****************************************************************************/
 
-#include <boost/python/class.hpp>
-#include <boost/python/def.hpp>
-#include <boost/python/copy_const_reference.hpp>
-#include <boost/python/register_ptr_to_python.hpp>
+#include <nanobind/nanobind.h>
+#include <nanobind/trampoline.h>
 
 #include <string>
 
@@ -35,8 +33,6 @@
 namespace srrealmodule {
 namespace nswrap_PeakProfile {
 
-using namespace boost;
-using namespace boost::python;
 using namespace diffpy::srreal;
 
 // docstrings ----------------------------------------------------------------
@@ -110,61 +106,84 @@ The profile is also rescaled to keep the integrated area of 1.\n\
 // Support for override of PeakProfile methods from Python.
 
 class PeakProfileWrap :
-    public PeakProfile,
-    public wrapper_srreal<PeakProfile>
+    public PeakProfile
 {
     public:
 
+        NB_TRAMPOLINE(PeakProfile, 7);
+
         // HasClassRegistry methods
 
-        PeakProfilePtr create() const
+        PeakProfilePtr create() const override
         {
-            object rv = this->get_pure_virtual_override("create")();
+            nb::gil_scoped_acquire gil;
+            nb::detail::ticket ticket(nb_trampoline, "create", true);
+
+            if (!ticket.key.is_valid()) 
+            {
+                    throw nb::type_error(
+                        "pure virtual method PeakProfile.create() called"
+                    );
+            }
+
+            nb::object rv = nb_trampoline.base().attr(ticket.key)();
             return mconfigurator.fetch(rv);
         }
 
-        PeakProfilePtr clone() const
+        PeakProfilePtr clone() const override
         {
-            return this->get_pure_virtual_override("clone")();
+            NB_OVERRIDE_PURE(clone);
         }
 
 
-        const std::string& type() const
+        const std::string& type() const override
         {
-            python::object tp = this->get_pure_virtual_override("type")();
-            mtype = python::extract<std::string>(tp);
+            nb::gil_scoped_acquire gil;
+            nb::detail::ticket ticket(nb_trampoline, "type", true);
+
+            if (!ticket.key.is_valid()) 
+            {
+                throw nb::type_error(
+                    "pure virtual method PeakProfile.type() called"
+                );
+            }
+
+            nb::object tp = nb_trampoline.base().attr(ticket.key)();
+            mtype = nb::cast<std::string>(tp);
             return mtype;
         }
 
         // own methods
 
-        double operator()(double x, double fwhm) const
+        double operator()(double x, double fwhm) const override
         {
-            return this->get_pure_virtual_override("__call__")(x, fwhm);
+            NB_OVERRIDE_PURE_NAME("__call__", operator(), x, fwhm);
         }
 
-        double xboundlo(double fwhm) const
+        double xboundlo(double fwhm) const override
         {
-            return this->get_pure_virtual_override("xboundlo")(fwhm);
+            NB_OVERRIDE_PURE(xboundlo, fwhm);
         }
 
-        double xboundhi(double fwhm) const
+        double xboundhi(double fwhm) const override
         {
-            return this->get_pure_virtual_override("xboundhi")(fwhm);
+            NB_OVERRIDE_PURE(xboundhi, fwhm);
         }
 
         // Support for ticker override from Python.
 
-        diffpy::eventticker::EventTicker& ticker() const
+        diffpy::eventticker::EventTicker& ticker() const override
         {
             using diffpy::eventticker::EventTicker;
-            override f = this->get_override("ticker");
-            if (f)
+            nb::gil_scoped_acquire gil;
+            nb::detail::ticket ticket(nb_trampoline, "ticker", false);
+
+            if (ticket.key.is_valid()) 
             {
-                // avoid "dangling reference error" when used from C++
-                python::object ptic = f();
-                return python::extract<EventTicker&>(ptic);
+                nb::object ptic = nb_trampoline.base().attr(ticket.key)();
+                return nb::cast<EventTicker&>(ptic);
             }
+
             return this->default_ticker();
         }
 
@@ -177,7 +196,7 @@ class PeakProfileWrap :
 
         // HasClassRegistry method
 
-        void setupRegisteredObject(PeakProfilePtr p) const
+        void setupRegisteredObject(PeakProfilePtr p) const override
         {
             mconfigurator.setup(p);
         }
@@ -202,40 +221,42 @@ class PeakProfileWrap :
 
 // Wrapper definition --------------------------------------------------------
 
-void wrap_PeakProfile()
+void wrap_PeakProfile(nb::module_& m)
 {
     using namespace nswrap_PeakProfile;
     using diffpy::Attributes;
-    namespace bp = boost::python;
 
-    class_<PeakProfileWrap, bases<Attributes>, noncopyable>
-        peakprofile("PeakProfile", doc_PeakProfile);
+    nb::class_<PeakProfile, Attributes, PeakProfileWrap>
+        peakprofile(m, "PeakProfile", nb::dynamic_attr(), doc_PeakProfile);
     wrap_registry_methods(peakprofile)
+        .def(nb::init<>())
         .def("__call__", &PeakProfile::operator(),
-                (bp::arg("x"), bp::arg("fwhm")), doc_PeakProfile___call__)
+                nb::arg("x"), nb::arg("fwhm"), doc_PeakProfile___call__)
         .def("xboundlo", &PeakProfile::xboundlo,
-                bp::arg("fwhm"), doc_PeakProfile_xboundlo)
+                nb::arg("fwhm"), doc_PeakProfile_xboundlo)
         .def("xboundhi", &PeakProfile::xboundhi,
-                bp::arg("fwhm"), doc_PeakProfile_xboundhi)
+                nb::arg("fwhm"), doc_PeakProfile_xboundhi)
         .def("ticker",
                 &PeakProfile::ticker,
-                &PeakProfileWrap::default_ticker,
-                return_internal_reference<>(),
+                nb::rv_policy::reference_internal,
                 doc_PeakProfile_ticker)
-        .def_pickle(SerializationPickleSuite<PeakProfile,DICT_PICKLE>())
         ;
 
-    register_ptr_to_python<PeakProfilePtr>();
+    SerializationPickleSuite<PeakProfile, DICT_PICKLE>::bind(peakprofile);
 
-    class_<GaussianProfile, bases<PeakProfile> >(
-            "GaussianProfile", doc_GaussianProfile)
-        .def_pickle(SerializationPickleSuite<GaussianProfile>())
+    nb::class_<GaussianProfile, PeakProfile> gaussianprofile(m,
+            "GaussianProfile", doc_GaussianProfile);
+    gaussianprofile
+        .def(nb::init<>())
         ;
+        SerializationPickleSuite<GaussianProfile, DICT_IGNORE>::bind(gaussianprofile);
 
-    class_<CroppedGaussianProfile, bases<GaussianProfile> >(
-            "CroppedGaussianProfile", doc_CroppedGaussianProfile)
-        .def_pickle(SerializationPickleSuite<CroppedGaussianProfile>())
+    nb::class_<CroppedGaussianProfile, GaussianProfile> croppedgaussianprofile(m,
+            "CroppedGaussianProfile", doc_CroppedGaussianProfile);
+    croppedgaussianprofile
+        .def(nb::init<>())
         ;
+        SerializationPickleSuite<CroppedGaussianProfile, DICT_IGNORE>::bind(croppedgaussianprofile);
 
 }
 

--- a/src/extensions/wrap_PeakProfile.cpp
+++ b/src/extensions/wrap_PeakProfile.cpp
@@ -238,6 +238,13 @@ void wrap_PeakProfile(nb::module_& m)
         .def("xboundhi", &PeakProfile::xboundhi,
                 nb::arg("fwhm"), doc_PeakProfile_xboundhi)
         .def("ticker",
+                [](const PeakProfile& obj)
+                    -> diffpy::eventticker::EventTicker&
+                {
+                    return obj.PeakProfile::ticker();
+                },
+                nb::rv_policy::reference_internal)
+        .def("ticker",
                 &PeakProfile::ticker,
                 nb::rv_policy::reference_internal,
                 doc_PeakProfile_ticker)
@@ -253,14 +260,14 @@ void wrap_PeakProfile(nb::module_& m)
     gaussianprofile
         .def(nb::init<>())
         ;
-        SerializationPickleSuite<GaussianProfile, DICT_IGNORE>::bind(gaussianprofile);
+        SerializationPickleSuite<GaussianProfile, DICT_GUARD>::bind(gaussianprofile);
 
     nb::class_<CroppedGaussianProfile, GaussianProfile> croppedgaussianprofile(m,
             "CroppedGaussianProfile", doc_CroppedGaussianProfile);
     croppedgaussianprofile
         .def(nb::init<>())
         ;
-        SerializationPickleSuite<CroppedGaussianProfile, DICT_IGNORE>::bind(croppedgaussianprofile);
+        SerializationPickleSuite<CroppedGaussianProfile, DICT_GUARD>::bind(croppedgaussianprofile);
 
 }
 

--- a/src/extensions/wrap_PeakProfile.cpp
+++ b/src/extensions/wrap_PeakProfile.cpp
@@ -120,7 +120,7 @@ class PeakProfileWrap :
             nb::gil_scoped_acquire gil;
             nb::detail::ticket ticket(nb_trampoline, "create", true);
 
-            if (!ticket.key.is_valid()) 
+            if (!ticket.key.is_valid())
             {
                     throw nb::type_error(
                         "pure virtual method PeakProfile.create() called"
@@ -142,7 +142,7 @@ class PeakProfileWrap :
             nb::gil_scoped_acquire gil;
             nb::detail::ticket ticket(nb_trampoline, "type", true);
 
-            if (!ticket.key.is_valid()) 
+            if (!ticket.key.is_valid())
             {
                 throw nb::type_error(
                     "pure virtual method PeakProfile.type() called"
@@ -179,7 +179,7 @@ class PeakProfileWrap :
             nb::gil_scoped_acquire gil;
             nb::detail::ticket ticket(nb_trampoline, "ticker", false);
 
-            if (ticket.key.is_valid()) 
+            if (ticket.key.is_valid())
             {
                 nb::object ptic = nb_trampoline.base().attr(ticket.key)();
                 return nb::cast<EventTicker&>(ptic);

--- a/src/extensions/wrap_PeakWidthModel.cpp
+++ b/src/extensions/wrap_PeakWidthModel.cpp
@@ -26,6 +26,7 @@
 #include <diffpy/srreal/ConstantPeakWidth.hpp>
 #include <diffpy/srreal/DebyeWallerPeakWidth.hpp>
 #include <diffpy/srreal/JeongPeakWidth.hpp>
+#include <diffpy/srreal/StructureAdapter.hpp>
 #include <diffpy/serialization.hpp>
 
 #include "srreal_converters.hpp"

--- a/src/extensions/wrap_PeakWidthModel.cpp
+++ b/src/extensions/wrap_PeakWidthModel.cpp
@@ -17,11 +17,8 @@
 *
 *****************************************************************************/
 
-#include <boost/python/class.hpp>
-#include <boost/python/def.hpp>
-#include <boost/python/copy_const_reference.hpp>
-#include <boost/python/register_ptr_to_python.hpp>
-#include <boost/serialization/export.hpp>
+#include <nanobind/nanobind.h>
+#include <nanobind/trampoline.h>
 
 #include <string>
 
@@ -35,11 +32,11 @@
 #include "srreal_pickling.hpp"
 #include "srreal_registry.hpp"
 
+namespace nb = nanobind;
+
 namespace srrealmodule {
 namespace nswrap_PeakWidthModel {
 
-using namespace boost;
-using namespace boost::python;
 using namespace diffpy::srreal;
 
 // docstrings ----------------------------------------------------------------
@@ -110,7 +107,7 @@ Use PeakWidthModel.getRegisteredTypes() for a set of registered names.\n\
 // wrappers ------------------------------------------------------------------
 
 double maxwidthwithpystructure(const PeakWidthModel& pwm,
-        python::object stru, double rmin, double rmax)
+        nb::object stru, double rmin, double rmax)
 {
     StructureAdapterPtr adpt = createStructureAdapter(stru);
     double rv = pwm.maxWidth(adpt, rmin, rmax);
@@ -129,57 +126,79 @@ DECLARE_BYTYPE_SETTER_WRAPPER(setPeakWidthModel, setpwmodel)
 // Support for Python override of the PeakWidthModel methods.
 
 class PeakWidthModelWrap :
-    public PeakWidthModel,
-    public wrapper_srreal<PeakWidthModel>
+    public PeakWidthModel
 {
     public:
 
+        NB_TRAMPOLINE(PeakWidthModel, 6);
+
         // HasClassRegistry methods
 
-        PeakWidthModelPtr create() const
+        PeakWidthModelPtr create() const override
         {
-            object rv = this->get_pure_virtual_override("create")();
+            nb::gil_scoped_acquire gil;
+            nb::detail::ticket ticket(nb_trampoline, "create", true);
+
+            if (!ticket.key.is_valid()) 
+            {
+                throw nb::type_error(
+                    "pure virtual method PeakWidthModel.create() called"
+                );
+            }
+
+            nb::object rv = nb_trampoline.base().attr(ticket.key)();
             return mconfigurator.fetch(rv);
         }
 
-        PeakWidthModelPtr clone() const
+        PeakWidthModelPtr clone() const override
         {
-            return this->get_pure_virtual_override("clone")();
+            NB_OVERRIDE_PURE(clone);
         }
 
-        const std::string& type() const
+        const std::string& type() const override
         {
-            python::object tp = this->get_pure_virtual_override("type")();
-            mtype = python::extract<std::string>(tp);
+            nb::gil_scoped_acquire gil;
+            nb::detail::ticket ticket(nb_trampoline, "type", true);
+
+            if (!ticket.key.is_valid()) 
+            {
+                throw nb::type_error(
+                    "pure virtual method PeakWidthModel.type() called"
+                );
+            }
+
+            nb::object tp = nb_trampoline.base().attr(ticket.key)();
+            mtype = nb::cast<std::string>(tp);
             return mtype;
         }
 
         // own methods
 
-        double calculate(const BaseBondGenerator& bnds) const
+        double calculate(const BaseBondGenerator& bnds) const override
         {
-            return this->get_pure_virtual_override("calculate")(ptr(&bnds));
+            NB_OVERRIDE_PURE(calculate, bnds);
         }
 
         double maxWidth(StructureAdapterPtr stru,
-                double rmin, double rmax) const
+                double rmin, double rmax) const override
         {
-            override f = this->get_pure_virtual_override("maxWidth");
-            return f(stru, rmin, rmax);
+            NB_OVERRIDE_PURE(maxWidth, stru, rmin, rmax);
         }
 
         // Make the ticker method overridable from Python
 
-        diffpy::eventticker::EventTicker& ticker() const
+        diffpy::eventticker::EventTicker& ticker() const override
         {
             using diffpy::eventticker::EventTicker;
-            override f = this->get_override("ticker");
-            if (f)
+            nb::gil_scoped_acquire gil;
+            nb::detail::ticket ticket(nb_trampoline, "ticker", false);
+
+            if (ticket.key.is_valid()) 
             {
-                // avoid "dangling reference error" when used from C++
-                python::object ptic = f();
-                return python::extract<EventTicker&>(ptic);
+                nb::object ptic = nb_trampoline.base().attr(ticket.key)();
+                return nb::cast<EventTicker&>(ptic);
             }
+
             return this->default_ticker();
         }
 
@@ -192,7 +211,7 @@ class PeakWidthModelWrap :
 
         // HasClassRegistry method
 
-        void setupRegisteredObject(PeakWidthModelPtr p) const
+        void setupRegisteredObject(PeakWidthModelPtr p) const override
         {
             mconfigurator.setup(p);
         }
@@ -217,53 +236,56 @@ class PeakWidthModelWrap :
 
 // Wrapper definition --------------------------------------------------------
 
-void wrap_PeakWidthModel()
+void wrap_PeakWidthModel(nb::module_& m)
 {
-    namespace bp = boost::python;
     using namespace nswrap_PeakWidthModel;
     using diffpy::Attributes;
 
-    class_<PeakWidthModelWrap, bases<Attributes>, noncopyable>
-        peakwidthmodel("PeakWidthModel", doc_PeakWidthModel);
+    nb::class_<PeakWidthModel, Attributes, PeakWidthModelWrap>
+        peakwidthmodel(m, "PeakWidthModel", nb::dynamic_attr(), doc_PeakWidthModel);
     wrap_registry_methods(peakwidthmodel)
+        .def(nb::init<>())
         .def("calculate",
                 &PeakWidthModel::calculate,
-                bp::arg("bnds"),
+                nb::arg("bnds"),
                 doc_PeakWidthModel_calculate)
         .def("maxWidth",
                 &PeakWidthModel::maxWidth,
-                (bp::arg("stru"), bp::arg("rmin"), bp::arg("rmax")),
+                nb::arg("stru"), nb::arg("rmin"), nb::arg("rmax"),
                 doc_PeakWidthModel_maxWidth)
         .def("maxWidth",
                 maxwidthwithpystructure,
-                (bp::arg("stru"), bp::arg("rmin"), bp::arg("rmax")))
+                nb::arg("stru"), nb::arg("rmin"), nb::arg("rmax"))
         .def("ticker",
                 &PeakWidthModel::ticker,
-                &PeakWidthModelWrap::default_ticker,
-                return_internal_reference<>(),
+                nb::rv_policy::reference_internal,
                 doc_PeakWidthModel_ticker)
-        .def_pickle(SerializationPickleSuite<PeakWidthModel,DICT_PICKLE>())
         ;
+        SerializationPickleSuite<PeakWidthModel, DICT_PICKLE>::bind(peakwidthmodel);
 
-    register_ptr_to_python<PeakWidthModelPtr>();
-
-    class_<ConstantPeakWidth, bases<PeakWidthModel> >(
-            "ConstantPeakWidth", doc_ConstantPeakWidth)
-        .def_pickle(SerializationPickleSuite<ConstantPeakWidth,DICT_IGNORE>())
+    nb::class_<ConstantPeakWidth, PeakWidthModel> constantpeakwidth(m,
+            "ConstantPeakWidth", doc_ConstantPeakWidth);
+    constantpeakwidth
+        .def(nb::init<>())
         ;
-
-    class_<DebyeWallerPeakWidth, bases<PeakWidthModel> >(
-            "DebyeWallerPeakWidth", doc_DebyeWallerPeakWidth)
-        .def_pickle(SerializationPickleSuite<DebyeWallerPeakWidth,DICT_IGNORE>())
+        SerializationPickleSuite<ConstantPeakWidth, DICT_IGNORE>::bind(constantpeakwidth);
+    
+    nb::class_<DebyeWallerPeakWidth, PeakWidthModel> debywallerpeakwidth(m,
+            "DebyeWallerPeakWidth", doc_DebyeWallerPeakWidth);
+    debywallerpeakwidth
+        .def(nb::init<>())
         ;
+        SerializationPickleSuite<DebyeWallerPeakWidth, DICT_IGNORE>::bind(debywallerpeakwidth);
 
-    class_<JeongPeakWidth, bases<DebyeWallerPeakWidth> >(
-            "JeongPeakWidth", doc_JeongPeakWidth)
-        .def_pickle(SerializationPickleSuite<JeongPeakWidth,DICT_IGNORE>())
+    nb::class_<JeongPeakWidth, DebyeWallerPeakWidth> jeongpeakwidth(m,
+            "JeongPeakWidth", doc_JeongPeakWidth);
+    jeongpeakwidth
+        .def(nb::init<>())
         ;
+        SerializationPickleSuite<JeongPeakWidth, DICT_IGNORE>::bind(jeongpeakwidth);
 
-    class_<PeakWidthModelOwner>("PeakWidthModelOwner", doc_PeakWidthModelOwner)
-        .add_property("peakwidthmodel",
+    nb::class_<PeakWidthModelOwner>(m, "PeakWidthModelOwner", doc_PeakWidthModelOwner)
+        .def_prop_rw("peakwidthmodel",
                 getpwmodel,
                 setpwmodel<PeakWidthModelOwner,PeakWidthModel>,
                 doc_PeakWidthModelOwner_peakwidthmodel)

--- a/src/extensions/wrap_PeakWidthModel.cpp
+++ b/src/extensions/wrap_PeakWidthModel.cpp
@@ -115,6 +115,14 @@ double maxwidthwithpystructure(const PeakWidthModel& pwm,
     return rv;
 }
 
+
+nb::object borrowed_bond_generator(const BaseBondGenerator& bnds)
+{
+    return nb::cast(
+        const_cast<BaseBondGenerator*>(&bnds),
+        nb::rv_policy::reference);
+}
+
 // wrappers for the peakwidthmodel property
 
 PeakWidthModelPtr getpwmodel(PeakWidthModelOwner& obj)
@@ -178,7 +186,19 @@ class PeakWidthModelWrap :
 
         double calculate(const BaseBondGenerator& bnds) const override
         {
-            NB_OVERRIDE_PURE(calculate, bnds);
+            nb::gil_scoped_acquire gil;
+            nb::detail::ticket ticket(nb_trampoline, "calculate", true);
+
+            if (!ticket.key.is_valid())
+            {
+                throw nb::type_error(
+                    "pure virtual method PeakWidthModel.calculate() called"
+                );
+            }
+
+            nb::object pybnds = borrowed_bond_generator(bnds);
+            return nb::cast<double>(
+                nb_trampoline.base().attr(ticket.key)(pybnds));
         }
 
         double maxWidth(StructureAdapterPtr stru,
@@ -259,6 +279,13 @@ void wrap_PeakWidthModel(nb::module_& m)
                 maxwidthwithpystructure,
                 nb::arg("stru"), nb::arg("rmin"), nb::arg("rmax"))
         .def("ticker",
+                [](const PeakWidthModel& obj)
+                    -> diffpy::eventticker::EventTicker&
+                {
+                    return obj.PeakWidthModel::ticker();
+                },
+                nb::rv_policy::reference_internal)
+        .def("ticker",
                 &PeakWidthModel::ticker,
                 nb::rv_policy::reference_internal,
                 doc_PeakWidthModel_ticker)
@@ -273,21 +300,21 @@ void wrap_PeakWidthModel(nb::module_& m)
     constantpeakwidth
         .def(nb::init<>())
         ;
-        SerializationPickleSuite<ConstantPeakWidth, DICT_IGNORE>::bind(constantpeakwidth);
+        SerializationPickleSuite<ConstantPeakWidth, DICT_GUARD>::bind(constantpeakwidth);
     
     nb::class_<DebyeWallerPeakWidth, PeakWidthModel> debywallerpeakwidth(m,
             "DebyeWallerPeakWidth", doc_DebyeWallerPeakWidth);
     debywallerpeakwidth
         .def(nb::init<>())
         ;
-        SerializationPickleSuite<DebyeWallerPeakWidth, DICT_IGNORE>::bind(debywallerpeakwidth);
+        SerializationPickleSuite<DebyeWallerPeakWidth, DICT_GUARD>::bind(debywallerpeakwidth);
 
     nb::class_<JeongPeakWidth, DebyeWallerPeakWidth> jeongpeakwidth(m,
             "JeongPeakWidth", doc_JeongPeakWidth);
     jeongpeakwidth
         .def(nb::init<>())
         ;
-        SerializationPickleSuite<JeongPeakWidth, DICT_IGNORE>::bind(jeongpeakwidth);
+        SerializationPickleSuite<JeongPeakWidth, DICT_GUARD>::bind(jeongpeakwidth);
 
     nb::class_<PeakWidthModelOwner>(m, "PeakWidthModelOwner", doc_PeakWidthModelOwner)
         .def(nb::init<>())

--- a/src/extensions/wrap_PeakWidthModel.cpp
+++ b/src/extensions/wrap_PeakWidthModel.cpp
@@ -285,6 +285,7 @@ void wrap_PeakWidthModel(nb::module_& m)
         SerializationPickleSuite<JeongPeakWidth, DICT_IGNORE>::bind(jeongpeakwidth);
 
     nb::class_<PeakWidthModelOwner>(m, "PeakWidthModelOwner", doc_PeakWidthModelOwner)
+        .def(nb::init<>())
         .def_prop_rw("peakwidthmodel",
                 getpwmodel,
                 setpwmodel<PeakWidthModelOwner,PeakWidthModel>,

--- a/src/extensions/wrap_PeakWidthModel.cpp
+++ b/src/extensions/wrap_PeakWidthModel.cpp
@@ -127,7 +127,8 @@ DECLARE_BYTYPE_SETTER_WRAPPER(setPeakWidthModel, setpwmodel)
 // Support for Python override of the PeakWidthModel methods.
 
 class PeakWidthModelWrap :
-    public PeakWidthModel
+    public PeakWidthModel,
+    public PythonTrampolineTag
 {
     public:
 
@@ -262,7 +263,10 @@ void wrap_PeakWidthModel(nb::module_& m)
                 nb::rv_policy::reference_internal,
                 doc_PeakWidthModel_ticker)
         ;
-        SerializationPickleSuite<PeakWidthModel, DICT_PICKLE>::bind(peakwidthmodel);
+        SerializationPickleSuite<
+            PeakWidthModel,
+            DICT_PICKLE,
+            PeakWidthModelWrap>::bind(peakwidthmodel);
 
     nb::class_<ConstantPeakWidth, PeakWidthModel> constantpeakwidth(m,
             "ConstantPeakWidth", doc_ConstantPeakWidth);

--- a/src/extensions/wrap_PeakWidthModel.cpp
+++ b/src/extensions/wrap_PeakWidthModel.cpp
@@ -149,7 +149,7 @@ class PeakWidthModelWrap :
             nb::gil_scoped_acquire gil;
             nb::detail::ticket ticket(nb_trampoline, "create", true);
 
-            if (!ticket.key.is_valid()) 
+            if (!ticket.key.is_valid())
             {
                 throw nb::type_error(
                     "pure virtual method PeakWidthModel.create() called"
@@ -170,7 +170,7 @@ class PeakWidthModelWrap :
             nb::gil_scoped_acquire gil;
             nb::detail::ticket ticket(nb_trampoline, "type", true);
 
-            if (!ticket.key.is_valid()) 
+            if (!ticket.key.is_valid())
             {
                 throw nb::type_error(
                     "pure virtual method PeakWidthModel.type() called"
@@ -215,7 +215,7 @@ class PeakWidthModelWrap :
             nb::gil_scoped_acquire gil;
             nb::detail::ticket ticket(nb_trampoline, "ticker", false);
 
-            if (ticket.key.is_valid()) 
+            if (ticket.key.is_valid())
             {
                 nb::object ptic = nb_trampoline.base().attr(ticket.key)();
                 return nb::cast<EventTicker&>(ptic);
@@ -301,7 +301,7 @@ void wrap_PeakWidthModel(nb::module_& m)
         .def(nb::init<>())
         ;
         SerializationPickleSuite<ConstantPeakWidth, DICT_GUARD>::bind(constantpeakwidth);
-    
+
     nb::class_<DebyeWallerPeakWidth, PeakWidthModel> debywallerpeakwidth(m,
             "DebyeWallerPeakWidth", doc_DebyeWallerPeakWidth);
     debywallerpeakwidth

--- a/src/extensions/wrap_ScatteringFactorTable.cpp
+++ b/src/extensions/wrap_ScatteringFactorTable.cpp
@@ -211,7 +211,8 @@ DECLARE_BYTYPE_SETTER_WRAPPER(setScatteringFactorTable, setsftable)
 // Helper class to support Python override of ScatteringFactorTable methods
 
 class ScatteringFactorTableWrap :
-    public ScatteringFactorTable
+    public ScatteringFactorTable,
+    public PythonTrampolineTag
 {
     public:
 
@@ -413,7 +414,10 @@ void wrap_ScatteringFactorTable(nb::module_& m)
                 nb::rv_policy::reference_internal,
                 doc_ScatteringFactorTable_ticker)
         ;
-        SerializationPickleSuite<ScatteringFactorTable, DICT_PICKLE>::bind(sftb);
+        SerializationPickleSuite<
+            ScatteringFactorTable,
+            DICT_PICKLE,
+            ScatteringFactorTableWrap>::bind(sftb);
 
     nb::class_<SFTXray, ScatteringFactorTable> sftxray(m,
             "SFTXray", doc_SFTXray);

--- a/src/extensions/wrap_ScatteringFactorTable.cpp
+++ b/src/extensions/wrap_ScatteringFactorTable.cpp
@@ -410,6 +410,13 @@ void wrap_ScatteringFactorTable(nb::module_& m)
         .def("getCustomSymbols", getCustomSymbols_asset<ScatteringFactorTable>,
                 doc_ScatteringFactorTable_getCustomSymbols)
         .def("ticker",
+                [](const ScatteringFactorTable& obj)
+                    -> diffpy::eventticker::EventTicker&
+                {
+                    return obj.ScatteringFactorTable::ticker();
+                },
+                nb::rv_policy::reference_internal)
+        .def("ticker",
                 &ScatteringFactorTable::ticker,
                 nb::rv_policy::reference_internal,
                 doc_ScatteringFactorTable_ticker)
@@ -424,28 +431,28 @@ void wrap_ScatteringFactorTable(nb::module_& m)
     sftxray
         .def(nb::init<>())
         ;
-        SerializationPickleSuite<SFTXray, DICT_IGNORE>::bind(sftxray);
+        SerializationPickleSuite<SFTXray, DICT_GUARD>::bind(sftxray);
 
     nb::class_<SFTElectron, ScatteringFactorTable> sftelectron(m,
             "SFTElectron", doc_SFTElectron);
     sftelectron
         .def(nb::init<>())
         ;
-        SerializationPickleSuite<SFTElectron, DICT_IGNORE>::bind(sftelectron);
+        SerializationPickleSuite<SFTElectron, DICT_GUARD>::bind(sftelectron);
 
     nb::class_<SFTNeutron, ScatteringFactorTable> sftneutron(m,
             "SFTNeutron", doc_SFTNeutron);
     sftneutron
         .def(nb::init<>())
         ;
-        SerializationPickleSuite<SFTNeutron, DICT_IGNORE>::bind(sftneutron);
+        SerializationPickleSuite<SFTNeutron, DICT_GUARD>::bind(sftneutron);
 
     nb::class_<SFTElectronNumber, ScatteringFactorTable> sftelectronnumber(m,
             "SFTElectronNumber", doc_SFTElectronNumber);
     sftelectronnumber
         .def(nb::init<>())
         ;
-        SerializationPickleSuite<SFTElectronNumber, DICT_IGNORE>::bind(sftelectronnumber);
+        SerializationPickleSuite<SFTElectronNumber, DICT_GUARD>::bind(sftelectronnumber);
 
     nb::class_<ScatteringFactorTableOwner>(m, "ScatteringFactorTableOwner",
             doc_ScatteringFactorTableOwner)

--- a/src/extensions/wrap_ScatteringFactorTable.cpp
+++ b/src/extensions/wrap_ScatteringFactorTable.cpp
@@ -17,9 +17,8 @@
 *
 *****************************************************************************/
 
-#include <boost/python/class.hpp>
-#include <boost/python/copy_const_reference.hpp>
-#include <boost/python/register_ptr_to_python.hpp>
+#include <nanobind/nanobind.h>
+#include <nanobind/trampoline.h>
 
 #include <diffpy/srreal/ScatteringFactorTable.hpp>
 #include <diffpy/srreal/SFTXray.hpp>
@@ -39,10 +38,11 @@
 #include "srreal_pickling.hpp"
 #include "srreal_registry.hpp"
 
+namespace nb = nanobind;
+
 namespace srrealmodule {
 namespace nswrap_ScatteringFactorTable {
 
-using namespace boost::python;
 using namespace diffpy::srreal;
 
 // docstrings
@@ -211,10 +211,11 @@ DECLARE_BYTYPE_SETTER_WRAPPER(setScatteringFactorTable, setsftable)
 // Helper class to support Python override of ScatteringFactorTable methods
 
 class ScatteringFactorTableWrap :
-    public ScatteringFactorTable,
-    public wrapper_srreal<ScatteringFactorTable>
+    public ScatteringFactorTable
 {
     public:
+
+        NB_TRAMPOLINE(ScatteringFactorTable, 6);
 
         // Copy Constructor
 
@@ -230,36 +231,66 @@ class ScatteringFactorTableWrap :
 
         // HasClassRegistry methods
 
-        ScatteringFactorTablePtr create() const
+        ScatteringFactorTablePtr create() const override
         {
-            object rv = this->get_pure_virtual_override("create")();
+            nb::gil_scoped_acquire gil;
+            nb::detail::ticket ticket(nb_trampoline, "create", true);
+
+            if (!ticket.key.is_valid()) 
+            {
+                throw nb::type_error(
+                    "pure virtual method ScatteringFactorTable.create() called"
+                );
+            }
+
+            nb::object rv = nb_trampoline.base().attr(ticket.key)();
             return mconfigurator.fetch(rv);
         }
 
-        ScatteringFactorTablePtr clone() const
+        ScatteringFactorTablePtr clone() const override
         {
-            return this->get_pure_virtual_override("clone")();
+            NB_OVERRIDE_PURE(clone);
         }
 
-        const std::string& type() const
+        const std::string& type() const override
         {
-            object tp = this->get_pure_virtual_override("type")();
-            mtype = extract<std::string>(tp);
+            nb::gil_scoped_acquire gil;
+            nb::detail::ticket ticket(nb_trampoline, "type", true);
+
+            if (!ticket.key.is_valid()) 
+            {
+                throw nb::type_error(
+                    "pure virtual method ScatteringFactorTable.type() called"
+                );
+            }
+
+            nb::object tp = nb_trampoline.base().attr(ticket.key)();
+            mtype = nb::cast<std::string>(tp);
             return mtype;
         }
 
         // own methods
 
-        const std::string& radiationType() const
+        const std::string& radiationType() const override
         {
-            object tp = this->get_pure_virtual_override("radiationType")();
-            mradiationtype = extract<std::string>(tp);
+            nb::gil_scoped_acquire gil;
+            nb::detail::ticket ticket(nb_trampoline, "radiationType", true);
+
+            if (!ticket.key.is_valid()) 
+            {
+                throw nb::type_error(
+                    "pure virtual method ScatteringFactorTable.radiationType() called"
+                );
+            }
+
+            nb::object tp = nb_trampoline.base().attr(ticket.key)();
+            mradiationtype = nb::cast<std::string>(tp);
             return mradiationtype;
         }
 
-        double standardLookup(const std::string& smbl, double q) const
+        double standardLookup(const std::string& smbl, double q) const override
         {
-            return this->get_pure_virtual_override("_standardLookup")(smbl, q);
+            NB_OVERRIDE_PURE_NAME("_standardLookup", standardLookup, smbl, q);
         }
 
 
@@ -268,13 +299,15 @@ class ScatteringFactorTableWrap :
         diffpy::eventticker::EventTicker& ticker() const
         {
             using diffpy::eventticker::EventTicker;
-            override f = this->get_override("ticker");
-            if (f)
+            nb::gil_scoped_acquire gil;
+            nb::detail::ticket ticket(nb_trampoline, "ticker", false);
+
+            if (ticket.key.is_valid()) 
             {
-                // avoid "dangling reference error" when used from C++
-                object ptic = f();
-                return extract<EventTicker&>(ptic);
+                nb::object ptic = nb_trampoline.base().attr(ticket.key)();
+                return nb::cast<EventTicker&>(ptic);
             }
+
             return this->default_ticker();
         }
 
@@ -287,7 +320,7 @@ class ScatteringFactorTableWrap :
 
         // HasClassRegistry method
 
-        void setupRegisteredObject(ScatteringFactorTablePtr p) const
+        void setupRegisteredObject(ScatteringFactorTablePtr p) const override
         {
             mconfigurator.setup(p);
         }
@@ -309,8 +342,8 @@ class ScatteringFactorTableWrap :
 
 };  // class ScatteringFactorTableWrap
 
-object lookupnparray(const ScatteringFactorTable& sftb,
-        std::string smbl, object& qobj)
+nb::object lookupnparray(const ScatteringFactorTable& sftb,
+        std::string smbl, nb::object& qobj)
 {
     NumPyArray_DoublePtr aa = extractNumPyDoubleArray(qobj);
     NumPyArray_DoublePtr bb = createNumPyDoubleArrayLike(aa.first);
@@ -328,77 +361,91 @@ object lookupnparray(const ScatteringFactorTable& sftb,
 }   // namespace nswrap_ScatteringFactorTable
 
 // Wrapper definition --------------------------------------------------------
+// TODO: rework pickle helpers
 
-void wrap_ScatteringFactorTable()
+void wrap_ScatteringFactorTable(nb::module_& m)
 {
-    namespace bp = boost::python;
-    using boost::noncopyable;
     using namespace nswrap_ScatteringFactorTable;
     typedef ScatteringFactorTableOwner SFTOwner;
 
-    class_<ScatteringFactorTableWrap, noncopyable>
-        sftb("ScatteringFactorTable", doc_ScatteringFactorTable);
+    nb::class_<ScatteringFactorTable, ScatteringFactorTableWrap>
+        sftb(m, "ScatteringFactorTable", nb::dynamic_attr(), doc_ScatteringFactorTable);
     wrap_registry_methods(sftb)
+        .def(nb::init<>())
         .def("radiationType",
-                &ScatteringFactorTable::radiationType,
-                return_value_policy<copy_const_reference>(),
+                [](const ScatteringFactorTable &obj) 
+                {
+                    return std::string(obj.radiationType());
+                },
                 doc_ScatteringFactorTable_radiationType)
         .def("lookup",
                 lookupnparray,
-                (bp::arg("smbl"), bp::arg("qarray")))
+                nb::arg("smbl"), nb::arg("qarray"))
         .def("lookup",
                 &ScatteringFactorTable::lookup,
-                (bp::arg("smbl"), bp::arg("q")=0.0),
+                nb::arg("smbl"), nb::arg("q")=0.0,
                 doc_ScatteringFactorTable_lookup)
         .def("_standardLookup",
                 &ScatteringFactorTable::standardLookup,
-                (bp::arg("smbl"), bp::arg("q")),
+                nb::arg("smbl"), nb::arg("q"),
                 doc_ScatteringFactorTable__standardLookup)
 
         .def("setCustomAs", (void (ScatteringFactorTable::*)
                 (const std::string&, const std::string&))
                 &ScatteringFactorTable::setCustomAs,
-                (bp::arg("smbl"), bp::arg("src")),
+                nb::arg("smbl"), nb::arg("src"),
                 doc_ScatteringFactorTable_setCustomAs2)
         .def("setCustomAs", (void (ScatteringFactorTable::*)
                 (const std::string&, const std::string&, double, double))
                 &ScatteringFactorTable::setCustomAs,
-                (bp::arg("smbl"), bp::arg("src"),
-                 bp::arg("sf"), bp::arg("q")=0.0),
+                nb::arg("smbl"), nb::arg("src"),
+                nb::arg("sf"), nb::arg("q")=0.0,
                 doc_ScatteringFactorTable_setCustomAs4)
 
         .def("resetCustom", &ScatteringFactorTable::resetCustom,
-                bp::arg("smbl"), doc_ScatteringFactorTable_resetCustom)
+                nb::arg("smbl"), doc_ScatteringFactorTable_resetCustom)
         .def("resetAll", &ScatteringFactorTable::resetAll,
                 doc_ScatteringFactorTable_resetAll)
         .def("getCustomSymbols", getCustomSymbols_asset<ScatteringFactorTable>,
                 doc_ScatteringFactorTable_getCustomSymbols)
         .def("ticker",
                 &ScatteringFactorTable::ticker,
-                &ScatteringFactorTableWrap::default_ticker,
-                return_internal_reference<>(),
+                nb::rv_policy::reference_internal,
                 doc_ScatteringFactorTable_ticker)
-        .def_pickle(SerializationPickleSuite<ScatteringFactorTable,DICT_PICKLE>())
         ;
+        SerializationPickleSuite<ScatteringFactorTable, DICT_PICKLE>::bind(sftb);
 
-    register_ptr_to_python<ScatteringFactorTablePtr>();
+    nb::class_<SFTXray, ScatteringFactorTable> sftxray(m,
+            "SFTXray", doc_SFTXray);
+    sftxray
+        .def(nb::init<>())
+        ;
+        SerializationPickleSuite<SFTXray, DICT_IGNORE>::bind(sftxray);
 
-    class_<SFTXray, bases<ScatteringFactorTable> >(
-            "SFTXray", doc_SFTXray)
-        .def_pickle(SerializationPickleSuite<SFTXray>());
-    class_<SFTElectron, bases<ScatteringFactorTable> >(
-            "SFTElectron", doc_SFTElectron)
-        .def_pickle(SerializationPickleSuite<SFTElectron>());
-    class_<SFTNeutron, bases<ScatteringFactorTable> >(
-            "SFTNeutron", doc_SFTNeutron)
-        .def_pickle(SerializationPickleSuite<SFTNeutron>());
-    class_<SFTElectronNumber, bases<ScatteringFactorTable> >(
-            "SFTElectronNumber", doc_SFTElectronNumber)
-        .def_pickle(SerializationPickleSuite<SFTElectronNumber>());
+    nb::class_<SFTElectron, ScatteringFactorTable> sftelectron(m,
+            "SFTElectron", doc_SFTElectron);
+    sftelectron
+        .def(nb::init<>())
+        ;
+        SerializationPickleSuite<SFTElectron, DICT_IGNORE>::bind(sftelectron);
 
-    class_<ScatteringFactorTableOwner>("ScatteringFactorTableOwner",
+    nb::class_<SFTNeutron, ScatteringFactorTable> sftneutron(m,
+            "SFTNeutron", doc_SFTNeutron);
+    sftneutron
+        .def(nb::init<>())
+        ;
+        SerializationPickleSuite<SFTNeutron, DICT_IGNORE>::bind(sftneutron);
+
+    nb::class_<SFTElectronNumber, ScatteringFactorTable> sftelectronnumber(m,
+            "SFTElectronNumber", doc_SFTElectronNumber);
+    sftelectronnumber
+        .def(nb::init<>())
+        ;
+        SerializationPickleSuite<SFTElectronNumber, DICT_IGNORE>::bind(sftelectronnumber);
+
+    nb::class_<ScatteringFactorTableOwner>(m, "ScatteringFactorTableOwner",
             doc_ScatteringFactorTableOwner)
-        .add_property("scatteringfactortable",
+        .def_prop_rw("scatteringfactortable",
                 getsftable,
                 setsftable<ScatteringFactorTableOwner,ScatteringFactorTable>,
                 doc_ScatteringFactorTableOwner_scatteringfactortable)
@@ -406,27 +453,28 @@ void wrap_ScatteringFactorTable()
         .def("setScatteringFactorTableByType",
             +[](SFTOwner& obj, const std::string& tp)
             {
-                namespace bp = boost::python;
                 try
                 {
-                bp::object warnings = bp::import("warnings");
-                bp::object builtins = bp::import("builtins");
-                bp::object DeprecationWarning = builtins.attr("DeprecationWarning");
-                warnings.attr("warn")(
-                    std::string("setScatteringFactorTableByType is deprecated; "
-                            "assign the 'scatteringfactortable' property directly, for example:\n"
-                            "obj.scatteringfactortable = SFTNeutron()"),
-                    DeprecationWarning,
-                    2);
+                    nb::object warnings = nb::module_::import_("warnings");
+                    nb::object builtins = nb::module_::import_("builtins");
+                    nb::object DeprecationWarning = builtins.attr("DeprecationWarning");
+                    warnings.attr("warn")(
+                        std::string("setScatteringFactorTableByType is deprecated; "
+                                "assign the 'scatteringfactortable' property directly, for example:\n"
+                                "obj.scatteringfactortable = SFTNeutron()"),
+                        DeprecationWarning,
+                        2);
                 }
                 catch (...) { /* don't let warnings break the binding */ }
                 obj.setScatteringFactorTableByType(tp);
             },
-            bp::arg("tp"),
+            nb::arg("tp"),
             doc_ScatteringFactorTableOwner_setScatteringFactorTableByType)
         .def("getRadiationType",
-                &SFTOwner::getRadiationType,
-                return_value_policy<copy_const_reference>(),
+                [](const SFTOwner &obj) 
+                {
+                    return std::string(obj.getRadiationType());
+                },
                 doc_ScatteringFactorTableOwner_getRadiationType)
         ;
 }

--- a/src/extensions/wrap_ScatteringFactorTable.cpp
+++ b/src/extensions/wrap_ScatteringFactorTable.cpp
@@ -445,6 +445,7 @@ void wrap_ScatteringFactorTable(nb::module_& m)
 
     nb::class_<ScatteringFactorTableOwner>(m, "ScatteringFactorTableOwner",
             doc_ScatteringFactorTableOwner)
+        .def(nb::init<>())
         .def_prop_rw("scatteringfactortable",
                 getsftable,
                 setsftable<ScatteringFactorTableOwner,ScatteringFactorTable>,

--- a/src/extensions/wrap_ScatteringFactorTable.cpp
+++ b/src/extensions/wrap_ScatteringFactorTable.cpp
@@ -237,7 +237,7 @@ class ScatteringFactorTableWrap :
             nb::gil_scoped_acquire gil;
             nb::detail::ticket ticket(nb_trampoline, "create", true);
 
-            if (!ticket.key.is_valid()) 
+            if (!ticket.key.is_valid())
             {
                 throw nb::type_error(
                     "pure virtual method ScatteringFactorTable.create() called"
@@ -258,7 +258,7 @@ class ScatteringFactorTableWrap :
             nb::gil_scoped_acquire gil;
             nb::detail::ticket ticket(nb_trampoline, "type", true);
 
-            if (!ticket.key.is_valid()) 
+            if (!ticket.key.is_valid())
             {
                 throw nb::type_error(
                     "pure virtual method ScatteringFactorTable.type() called"
@@ -277,7 +277,7 @@ class ScatteringFactorTableWrap :
             nb::gil_scoped_acquire gil;
             nb::detail::ticket ticket(nb_trampoline, "radiationType", true);
 
-            if (!ticket.key.is_valid()) 
+            if (!ticket.key.is_valid())
             {
                 throw nb::type_error(
                     "pure virtual method ScatteringFactorTable.radiationType() called"
@@ -303,7 +303,7 @@ class ScatteringFactorTableWrap :
             nb::gil_scoped_acquire gil;
             nb::detail::ticket ticket(nb_trampoline, "ticker", false);
 
-            if (ticket.key.is_valid()) 
+            if (ticket.key.is_valid())
             {
                 nb::object ptic = nb_trampoline.base().attr(ticket.key)();
                 return nb::cast<EventTicker&>(ptic);
@@ -374,7 +374,7 @@ void wrap_ScatteringFactorTable(nb::module_& m)
     wrap_registry_methods(sftb)
         .def(nb::init<>())
         .def("radiationType",
-                [](const ScatteringFactorTable &obj) 
+                [](const ScatteringFactorTable &obj)
                 {
                     return std::string(obj.radiationType());
                 },
@@ -483,7 +483,7 @@ void wrap_ScatteringFactorTable(nb::module_& m)
             nb::arg("tp"),
             doc_ScatteringFactorTableOwner_setScatteringFactorTableByType)
         .def("getRadiationType",
-                [](const SFTOwner &obj) 
+                [](const SFTOwner &obj)
                 {
                     return std::string(obj.getRadiationType());
                 },

--- a/src/extensions/wrap_StructureAdapter.cpp
+++ b/src/extensions/wrap_StructureAdapter.cpp
@@ -258,10 +258,51 @@ nb::object siteCartesianUij_safe(const StructureAdapter& adpt, int i)
     return siteCartesianUij_asarray(adpt, i);
 }
 
+
+PyObject* restoreStructureAdapter(PyObject*, PyObject* args)
+{
+    PyObject* content = nullptr;
+    if (!PyArg_UnpackTuple(args, "_restoreStructureAdapter", 1, 1, &content))
+        return nullptr;
+    if (!PyBytes_Check(content))
+    {
+        PyErr_SetString(PyExc_TypeError, "expected bytes");
+        return nullptr;
+    }
+
+    char* buffer = nullptr;
+    Py_ssize_t size = 0;
+    if (PyBytes_AsStringAndSize(content, &buffer, &size) < 0)
+        return nullptr;
+
+    try
+    {
+        StructureAdapterPtr adapter =
+            createStructureAdapterFromString(std::string(buffer, size));
+        nb::object pyadapter = nb::cast(adapter);
+        return pyadapter.release().ptr();
+    }
+    catch (const std::exception& e)
+    {
+        PyErr_SetString(PyExc_RuntimeError, e.what());
+        return nullptr;
+    }
+}
+
+
+PyMethodDef restoreStructureAdapterDef = {
+    "_restoreStructureAdapter",
+    restoreStructureAdapter,
+    METH_VARARGS,
+    "Restore native C++ StructureAdapter from serialized bytes."
+};
+
+
 // Helper class necessary for wrapping a pure virtual methods
 
 class StructureAdapterWrap :
-    public StructureAdapter
+    public StructureAdapter,
+    public PythonTrampolineTag
 {
     public:
 
@@ -460,13 +501,24 @@ class StructureProxyPickleSuite
         static void bind(C& cls)
         {
             cls
-                .def("__reduce__", [](T& self)
+                .def("__reduce__", [](nb::object self)
                 {
-                    StructureAdapterPtr src = self.getSourceStructure();
+                    T& adapter = nb::cast<T&>(self);
+                    StructureAdapterPtr src = adapter.getSourceStructure();
+                    nb::object dict = get_instance_dict(self);
+
+                    if (dict.is_none() || nb::len(dict) == 0)
+                    {
+                        return nb::make_tuple(
+                            runtime_type(self),
+                            nb::make_tuple(src)
+                        );
+                    }
 
                     return nb::make_tuple(
-                        nb::type<T>(),
-                        nb::make_tuple(src)
+                        runtime_type(self),
+                        nb::make_tuple(src),
+                        nb::make_tuple(nb::none(), dict)
                     );
                 })
                 ;
@@ -543,7 +595,8 @@ void wrap_StructureAdapter(nb::module_& m)
                 nb::arg("other"),
                 doc_StructureAdapter_diff)
         ;
-        StructureAdapterPickleSuite<StructureAdapter>::bind(structureadapter);
+        StructureAdapterPickleSuite<StructureAdapter, StructureAdapterWrap>::bind(
+            structureadapter);
 
     typedef std::shared_ptr<NoMetaStructureAdapter>
         NoMetaStructureAdapterPtr;
@@ -569,6 +622,17 @@ void wrap_StructureAdapter(nb::module_& m)
     m.def("nosymmetry", nosymmetry<nb::object>, doc_nosymmetry);
     m.def("_emptyStructureAdapter", emptyStructureAdapter,
             doc__emptyStructureAdapter);
+    nb::object module_name = nb::str("diffpy.srreal.srreal_ext");
+    PyObject* restore_function = PyCFunction_NewEx(
+        &restoreStructureAdapterDef, nullptr, module_name.ptr());
+    if (!restore_function)
+        nb::raise_python_error();
+    if (PyModule_AddObject(m.ptr(), "_restoreStructureAdapter",
+            restore_function) < 0)
+    {
+        Py_DECREF(restore_function);
+        nb::raise_python_error();
+    }
 }
 
 // Export shared docstrings

--- a/src/extensions/wrap_StructureAdapter.cpp
+++ b/src/extensions/wrap_StructureAdapter.cpp
@@ -446,7 +446,7 @@ class StructureProxyPickleSuite : public boost::python::pickle_suite
                 diffpy::srreal::StructureAdapterPtr adpt)
         {
             using namespace boost;
-            shared_ptr<T> tadpt = dynamic_pointer_cast<T>(adpt);
+            std::shared_ptr<T> tadpt = std::dynamic_pointer_cast<T>(adpt);
             StructureAdapterPtr srcadpt = tadpt->getSourceStructure();
             python::tuple rv = python::make_tuple(srcadpt);
             return rv;
@@ -540,7 +540,7 @@ void wrap_StructureAdapter()
     register_ptr_to_python<StructureAdapterPtr>();
     implicitly_convertible<StructureAdapterPtr, StructureAdapterConstPtr>();
 
-    typedef boost::shared_ptr<NoMetaStructureAdapter>
+    typedef std::shared_ptr<NoMetaStructureAdapter>
         NoMetaStructureAdapterPtr;
     class_<NoMetaStructureAdapter,
         bases<StructureAdapter>, NoMetaStructureAdapterPtr>(
@@ -550,7 +550,7 @@ void wrap_StructureAdapter()
         .def_pickle(StructureProxyPickleSuite<NoMetaStructureAdapter>())
         ;
 
-    typedef boost::shared_ptr<NoSymmetryStructureAdapter>
+    typedef std::shared_ptr<NoSymmetryStructureAdapter>
         NoSymmetryStructureAdapterPtr;
     class_<NoSymmetryStructureAdapter,
         bases<StructureAdapter>, NoSymmetryStructureAdapterPtr>(

--- a/src/extensions/wrap_StructureAdapter.cpp
+++ b/src/extensions/wrap_StructureAdapter.cpp
@@ -460,7 +460,7 @@ class StructureProxyPickleSuite
         static void bind(C& cls)
         {
             cls
-                .def("__reduce__", [](const T& self)
+                .def("__reduce__", [](T& self)
                 {
                     StructureAdapterPtr src = self.getSourceStructure();
 
@@ -503,8 +503,6 @@ void wrap_StructureAdapter(nb::module_& m)
             "StructureAdapter", doc_StructureAdapter);
     structureadapter
         .def(nb::init<>())
-        .def("__init__", StructureAdapter_constructor<StructureAdapter>,
-                doc_StructureAdapter___init__fromstring)
         .def("clone",
                 &StructureAdapter::clone,
                 doc_StructureAdapter_clone)
@@ -545,7 +543,7 @@ void wrap_StructureAdapter(nb::module_& m)
                 nb::arg("other"),
                 doc_StructureAdapter_diff)
         ;
-        StructureProxyPickleSuite<StructureAdapter>::bind(structureadapter);
+        StructureAdapterPickleSuite<StructureAdapter>::bind(structureadapter);
 
     typedef std::shared_ptr<NoMetaStructureAdapter>
         NoMetaStructureAdapterPtr;

--- a/src/extensions/wrap_StructureAdapter.cpp
+++ b/src/extensions/wrap_StructureAdapter.cpp
@@ -18,11 +18,9 @@
 *
 *****************************************************************************/
 
-#include <boost/python/class.hpp>
-#include <boost/python/def.hpp>
-#include <boost/python/copy_const_reference.hpp>
-#include <boost/python/register_ptr_to_python.hpp>
-#include <boost/python/implicit.hpp>
+#include <nanobind/nanobind.h>
+#include <nanobind/trampoline.h>
+#include <nanobind/stl/shared_ptr.h>
 
 #include "srreal_converters.hpp"
 #include "srreal_pickling.hpp"
@@ -33,15 +31,15 @@
 #include <diffpy/srreal/PairQuantity.hpp>
 #include <diffpy/serialization.ipp>
 
+namespace nb = nanobind;
+
 namespace srrealmodule {
 
 // declarations
-void sync_StructureDifference(boost::python::object obj);
+void sync_StructureDifference(nb::object obj);
 
 namespace nswrap_StructureAdapter {
 
-using namespace boost;
-using namespace boost::python;
 using namespace diffpy::srreal;
 
 // docstrings ----------------------------------------------------------------
@@ -223,7 +221,7 @@ const std::string& siteAtomType_safe(const StructureAdapter& adpt, int i)
 DECLARE_PYARRAY_METHOD_WRAPPER1(siteCartesianPosition,
         siteCartesianPosition_asarray)
 
-python::object siteCartesianPosition_safe(const StructureAdapter& adpt, int i)
+nb::object siteCartesianPosition_safe(const StructureAdapter& adpt, int i)
 {
     checkindex(adpt, i);
     return siteCartesianPosition_asarray(adpt, i);
@@ -254,7 +252,7 @@ bool siteAnisotropy_safe(const StructureAdapter& adpt, int i)
 DECLARE_PYARRAY_METHOD_WRAPPER1(siteCartesianUij,
         siteCartesianUij_asarray)
 
-python::object siteCartesianUij_safe(const StructureAdapter& adpt, int i)
+nb::object siteCartesianUij_safe(const StructureAdapter& adpt, int i)
 {
     checkindex(adpt, i);
     return siteCartesianUij_asarray(adpt, i);
@@ -263,33 +261,34 @@ python::object siteCartesianUij_safe(const StructureAdapter& adpt, int i)
 // Helper class necessary for wrapping a pure virtual methods
 
 class StructureAdapterWrap :
-    public StructureAdapter,
-    public wrapper_srreal<StructureAdapter>
+    public StructureAdapter
 {
     public:
 
-        StructureAdapterPtr clone() const
+        NB_TRAMPOLINE(StructureAdapter, 13);
+
+        StructureAdapterPtr clone() const override
         {
-            return this->get_pure_virtual_override("clone")();
+            NB_OVERRIDE_PURE(clone);
         }
 
 
-        BaseBondGeneratorPtr createBondGenerator() const
+        BaseBondGeneratorPtr createBondGenerator() const override
         {
-            return this->get_pure_virtual_override("createBondGenerator")();
+            NB_OVERRIDE_PURE(createBondGenerator);
         }
 
 
-        int countSites() const
+        int countSites() const override
         {
-            return this->get_pure_virtual_override("countSites")();
+            NB_OVERRIDE_PURE(countSites);
         }
 
 
+        // TODO: totalOccupancy is not marked as virtual function
+        // need to check behaviour
         double totalOccupancy() const
         {
-            override f = this->get_override("totalOccupancy");
-            if (f)  return f();
             return this->default_totalOccupancy();
         }
 
@@ -299,11 +298,9 @@ class StructureAdapterWrap :
         }
 
 
-        double numberDensity() const
+        double numberDensity() const override
         {
-            override f = this->get_override("numberDensity");
-            if (f)  return f();
-            return this->default_numberDensity();
+            NB_OVERRIDE(numberDensity);
         }
 
         double default_numberDensity() const
@@ -312,16 +309,19 @@ class StructureAdapterWrap :
         }
 
 
-        const std::string& siteAtomType(int idx) const
+        const std::string& siteAtomType(int idx) const override
         {
             static std::string rv;
-            override f = this->get_override("siteAtomType");
-            if (f)
+            nb::gil_scoped_acquire gil;
+            nb::detail::ticket ticket(nb_trampoline, "siteAtomType", false);
+
+            if (ticket.key.is_valid()) 
             {
-                python::object atp = f(idx);
-                rv = python::extract<std::string>(atp);
+                nb::object atp = nb_trampoline.base().attr(ticket.key)(idx);
+                rv = nb::cast<std::string>(atp);
                 return rv;
             }
+
             return this->default_siteAtomType(idx);
         }
 
@@ -331,24 +331,31 @@ class StructureAdapterWrap :
         }
 
 
-        const R3::Vector& siteCartesianPosition(int idx) const
+        const R3::Vector& siteCartesianPosition(int idx) const override
         {
             static R3::Vector rv;
-            python::object pos =
-                this->get_pure_virtual_override("siteCartesianPosition")(idx);
+            nb::gil_scoped_acquire gil;
+            nb::detail::ticket ticket(nb_trampoline, "siteCartesianPosition", true);
+
+            if (!ticket.key.is_valid()) 
+            {
+                throw nb::type_error(
+                    "pure virtual method StructureAdapter.siteCartesianPosition() called"
+                );
+            }
+
+            nb::object pos = nb_trampoline.base().attr(ticket.key)(idx);
             for (int i = 0; i < R3::Ndim; ++i)
             {
-                rv[i] = python::extract<double>(pos[i]);
+                rv[i] = nb::cast<double>(pos[i]);
             }
             return rv;
         }
 
 
-        int siteMultiplicity(int idx) const
+        int siteMultiplicity(int idx) const override
         {
-            override f = this->get_override("siteMultiplicity");
-            if (f)  return f(idx);
-            return this->default_siteMultiplicity(idx);
+            NB_OVERRIDE(siteMultiplicity, idx);
         }
 
         int default_siteMultiplicity(int idx) const
@@ -357,11 +364,9 @@ class StructureAdapterWrap :
         }
 
 
-        double siteOccupancy(int idx) const
+        double siteOccupancy(int idx) const override
         {
-            override f = this->get_override("siteOccupancy");
-            if (f)  return f(idx);
-            return this->default_siteOccupancy(idx);
+            NB_OVERRIDE(siteOccupancy, idx);
         }
 
         double default_siteOccupancy(int idx) const
@@ -370,33 +375,40 @@ class StructureAdapterWrap :
         }
 
 
-        bool siteAnisotropy(int idx) const
+        bool siteAnisotropy(int idx) const override
         {
-            return this->get_pure_virtual_override("siteAnisotropy")(idx);
+            NB_OVERRIDE_PURE(siteAnisotropy, idx);
         }
 
 
-        const R3::Matrix& siteCartesianUij(int idx) const
+        const R3::Matrix& siteCartesianUij(int idx) const override
         {
             static R3::Matrix rv;
-            python::object uij =
-                this->get_pure_virtual_override("siteCartesianUij")(idx);
+            nb::gil_scoped_acquire gil;
+            nb::detail::ticket ticket(nb_trampoline, "siteCartesianUij", true);
+
+            if (!ticket.key.is_valid()) 
+            {
+                throw nb::type_error(
+                    "pure virtual method StructureAdapter.siteCartesianUij() called"
+                );
+            }
+
+            nb::object uij = nb_trampoline.base().attr(ticket.key)(idx);
             for (int i = 0; i < R3::Ndim; ++i)
             {
                 for (int j = 0; j < R3::Ndim; ++j)
                 {
-                    rv(i, j) = python::extract<double>(uij[i][j]);
+                    rv(i, j) = nb::cast<double>(uij[i][j]);
                 }
             }
             return rv;
         }
 
 
-        void customPQConfig(PairQuantity* pq) const
+        void customPQConfig(PairQuantity* pq) const override
         {
-            override f = this->get_override("_customPQConfig");
-            if (f)  f(ptr(pq));
-            else    this->default_customPQConfig(pq);
+            NB_OVERRIDE_NAME("_customPQConfig", customPQConfig, pq);
         }
 
         void default_customPQConfig(PairQuantity* pq) const
@@ -405,17 +417,19 @@ class StructureAdapterWrap :
         }
 
 
-        StructureDifference diff(StructureAdapterConstPtr other) const
+        StructureDifference diff(StructureAdapterConstPtr other) const override
         {
-            override f = this->get_override("diff");
-            if (f)
-            {
-                python::object sdobj = f(other);
+            nb::gil_scoped_acquire gil;
+            nb::detail::ticket ticket(nb_trampoline, "diff", false);
+
+            if (ticket.key.is_valid()) {
+                nb::object sdobj = nb_trampoline.base().attr(ticket.key)(other);
                 sync_StructureDifference(sdobj);
-                StructureDifference& sd =
-                    python::extract<StructureDifference&>(sdobj);
+                StructureDifference &sd =
+                    nb::cast<StructureDifference&>(sdobj);
                 return sd;
             }
+
             return this->default_diff(other);
         }
 
@@ -438,18 +452,24 @@ class StructureAdapterWrap :
 
 
 template <class T>
-class StructureProxyPickleSuite : public boost::python::pickle_suite
+class StructureProxyPickleSuite
 {
     public:
 
-        static boost::python::tuple getinitargs(
-                diffpy::srreal::StructureAdapterPtr adpt)
+        template <typename C>
+        static void bind(C& cls)
         {
-            using namespace boost;
-            std::shared_ptr<T> tadpt = std::dynamic_pointer_cast<T>(adpt);
-            StructureAdapterPtr srcadpt = tadpt->getSourceStructure();
-            python::tuple rv = python::make_tuple(srcadpt);
-            return rv;
+            cls
+                .def("__reduce__", [](const T& self)
+                {
+                    StructureAdapterPtr src = self.getSourceStructure();
+
+                    return nb::make_tuple(
+                        nb::type<T>(),
+                        nb::make_tuple(src)
+                    );
+                })
+                ;
         }
 
 };
@@ -465,7 +485,7 @@ void checkindex(const StructureAdapter& adpt, int i)
     // Prevent out-of-bounds crash from C++ objects.
     if (0 <= i && i < adpt.countSites())  return;
     PyErr_SetString(PyExc_IndexError, "Index out of range.");
-    throw_error_already_set();
+    throw nb::python_error();
 }
 
 }   // namespace
@@ -475,13 +495,15 @@ void checkindex(const StructureAdapter& adpt, int i)
 
 // Wrapper definition --------------------------------------------------------
 
-void wrap_StructureAdapter()
+void wrap_StructureAdapter(nb::module_& m)
 {
     using namespace nswrap_StructureAdapter;
 
-    class_<StructureAdapterWrap, noncopyable>(
-            "StructureAdapter", doc_StructureAdapter)
-        .def("__init__", StructureAdapter_constructor(),
+    nb::class_<StructureAdapter, StructureAdapterWrap> structureadapter(m,
+            "StructureAdapter", doc_StructureAdapter);
+    structureadapter
+        .def(nb::init<>())
+        .def("__init__", StructureAdapter_constructor<StructureAdapter>,
                 doc_StructureAdapter___init__fromstring)
         .def("clone",
                 &StructureAdapter::clone,
@@ -493,31 +515,21 @@ void wrap_StructureAdapter()
                 doc_StructureAdapter_countSites)
         .def("totalOccupancy",
                 &StructureAdapter::totalOccupancy,
-                &StructureAdapterWrap::default_totalOccupancy,
                 doc_StructureAdapter_totalOccupancy)
         .def("numberDensity", &StructureAdapter::numberDensity,
-                &StructureAdapterWrap::default_numberDensity,
                 doc_StructureAdapter_numberDensity)
         .def("siteAtomType",
                 siteAtomType_safe,
-                return_value_policy<copy_const_reference>(),
                 doc_StructureAdapter_siteAtomType)
-        .def("siteAtomType",
-                &StructureAdapterWrap::default_siteAtomType,
-                return_value_policy<copy_const_reference>())
         .def("siteCartesianPosition",
                     siteCartesianPosition_safe,
                     doc_StructureAdapter_siteCartesianPosition)
         .def("siteMultiplicity",
                 siteMultiplicity_safe,
                 doc_StructureAdapter_siteMultiplicity)
-        .def("siteMultiplicity",
-                &StructureAdapterWrap::default_siteMultiplicity)
         .def("siteOccupancy",
                 siteOccupancy_safe,
                 doc_StructureAdapter_siteOccupancy)
-        .def("siteOccupancy",
-                &StructureAdapterWrap::default_siteOccupancy)
         .def("siteAnisotropy",
                 siteAnisotropy_safe,
                 doc_StructureAdapter_siteAnisotropy)
@@ -526,43 +538,38 @@ void wrap_StructureAdapter()
                 doc_StructureAdapter_siteCartesianUij)
         .def("_customPQConfig",
                 &StructureAdapter::customPQConfig,
-                &StructureAdapterWrap::default_customPQConfig,
-                python::arg("pqobj"),
+                nb::arg("pqobj"),
                 doc_StructureAdapter__customPQConfig)
         .def("diff",
                 &StructureAdapter::diff,
-                &StructureAdapterWrap::default_diff,
-                python::arg("other"),
+                nb::arg("other"),
                 doc_StructureAdapter_diff)
-        .def_pickle(StructureAdapterPickleSuite<StructureAdapterWrap>())
         ;
-
-    register_ptr_to_python<StructureAdapterPtr>();
-    implicitly_convertible<StructureAdapterPtr, StructureAdapterConstPtr>();
+        StructureProxyPickleSuite<StructureAdapter>::bind(structureadapter);
 
     typedef std::shared_ptr<NoMetaStructureAdapter>
         NoMetaStructureAdapterPtr;
-    class_<NoMetaStructureAdapter,
-        bases<StructureAdapter>, NoMetaStructureAdapterPtr>(
-            "NoMetaStructureAdapter", doc_NoMetaStructureAdapter)
-        .def(init<StructureAdapterPtr>(python::arg("adapter"),
-                    doc_NoMetaStructureAdapter_init))
-        .def_pickle(StructureProxyPickleSuite<NoMetaStructureAdapter>())
+    nb::class_<NoMetaStructureAdapter, StructureAdapter> nometastructureadapter(m,
+            "NoMetaStructureAdapter", doc_NoMetaStructureAdapter);
+    nometastructureadapter
+        .def(nb::init<StructureAdapterPtr>(), nb::arg("adapter"),
+                    doc_NoMetaStructureAdapter_init)
         ;
+        StructureProxyPickleSuite<NoMetaStructureAdapter>::bind(nometastructureadapter);
 
     typedef std::shared_ptr<NoSymmetryStructureAdapter>
         NoSymmetryStructureAdapterPtr;
-    class_<NoSymmetryStructureAdapter,
-        bases<StructureAdapter>, NoSymmetryStructureAdapterPtr>(
-            "NoSymmetryStructureAdapter", doc_NoSymmetryStructureAdapter)
-        .def(init<StructureAdapterPtr>(python::arg("adapter"),
-                    doc_NoSymmetryStructureAdapter_init))
-        .def_pickle(StructureProxyPickleSuite<NoSymmetryStructureAdapter>())
+    nb::class_<NoSymmetryStructureAdapter, StructureAdapter> nosymmetrystructureadapter(m,
+            "NoSymmetryStructureAdapter", doc_NoSymmetryStructureAdapter);
+    nosymmetrystructureadapter
+        .def(nb::init<StructureAdapterPtr>(), nb::arg("adapter"),
+                    doc_NoSymmetryStructureAdapter_init)
         ;
+        StructureProxyPickleSuite<NoSymmetryStructureAdapter>::bind(nosymmetrystructureadapter);
 
-    def("nometa", nometa<object>, doc_nometa);
-    def("nosymmetry", nosymmetry<object>, doc_nosymmetry);
-    def("_emptyStructureAdapter", emptyStructureAdapter,
+    m.def("nometa", nometa<nb::object>, doc_nometa);
+    m.def("nosymmetry", nosymmetry<nb::object>, doc_nosymmetry);
+    m.def("_emptyStructureAdapter", emptyStructureAdapter,
             doc__emptyStructureAdapter);
 }
 

--- a/src/extensions/wrap_StructureAdapter.cpp
+++ b/src/extensions/wrap_StructureAdapter.cpp
@@ -492,6 +492,48 @@ class StructureAdapterWrap :
 };  // class StructureAdapterWrap
 
 
+double numberDensity_dispatch(const StructureAdapter& adpt)
+{
+    const StructureAdapterWrap *wrap =
+        dynamic_cast<const StructureAdapterWrap *>(&adpt);
+    return wrap ? wrap->default_numberDensity() : adpt.numberDensity();
+}
+
+
+const std::string& siteAtomType_dispatch(const StructureAdapter& adpt, int i)
+{
+    const StructureAdapterWrap *wrap =
+        dynamic_cast<const StructureAdapterWrap *>(&adpt);
+    return wrap ? wrap->default_siteAtomType(i) : siteAtomType_safe(adpt, i);
+}
+
+
+int siteMultiplicity_dispatch(const StructureAdapter& adpt, int i)
+{
+    const StructureAdapterWrap *wrap =
+        dynamic_cast<const StructureAdapterWrap *>(&adpt);
+    return wrap ?
+        wrap->default_siteMultiplicity(i) :
+        siteMultiplicity_safe(adpt, i);
+}
+
+
+double siteOccupancy_dispatch(const StructureAdapter& adpt, int i)
+{
+    const StructureAdapterWrap *wrap =
+        dynamic_cast<const StructureAdapterWrap *>(&adpt);
+    return wrap ?
+        wrap->default_siteOccupancy(i) :
+        siteOccupancy_safe(adpt, i);
+}
+
+
+BaseBondGeneratorPtr createBondGenerator_shared(StructureAdapterPtr adpt)
+{
+    return adpt->createBondGenerator();
+}
+
+
 template <class T>
 class StructureProxyPickleSuite
 {
@@ -559,26 +601,26 @@ void wrap_StructureAdapter(nb::module_& m)
                 &StructureAdapter::clone,
                 doc_StructureAdapter_clone)
         .def("createBondGenerator",
-                &StructureAdapter::createBondGenerator,
+                createBondGenerator_shared,
                 doc_StructureAdapter_createBondGenerator)
         .def("countSites", &StructureAdapter::countSites,
                 doc_StructureAdapter_countSites)
         .def("totalOccupancy",
                 &StructureAdapter::totalOccupancy,
                 doc_StructureAdapter_totalOccupancy)
-        .def("numberDensity", &StructureAdapter::numberDensity,
+        .def("numberDensity", numberDensity_dispatch,
                 doc_StructureAdapter_numberDensity)
         .def("siteAtomType",
-                siteAtomType_safe,
+                siteAtomType_dispatch,
                 doc_StructureAdapter_siteAtomType)
         .def("siteCartesianPosition",
                     siteCartesianPosition_safe,
                     doc_StructureAdapter_siteCartesianPosition)
         .def("siteMultiplicity",
-                siteMultiplicity_safe,
+                siteMultiplicity_dispatch,
                 doc_StructureAdapter_siteMultiplicity)
         .def("siteOccupancy",
-                siteOccupancy_safe,
+                siteOccupancy_dispatch,
                 doc_StructureAdapter_siteOccupancy)
         .def("siteAnisotropy",
                 siteAnisotropy_safe,

--- a/src/extensions/wrap_StructureAdapter.cpp
+++ b/src/extensions/wrap_StructureAdapter.cpp
@@ -356,7 +356,7 @@ class StructureAdapterWrap :
             nb::gil_scoped_acquire gil;
             nb::detail::ticket ticket(nb_trampoline, "siteAtomType", false);
 
-            if (ticket.key.is_valid()) 
+            if (ticket.key.is_valid())
             {
                 nb::object atp = nb_trampoline.base().attr(ticket.key)(idx);
                 rv = nb::cast<std::string>(atp);
@@ -378,7 +378,7 @@ class StructureAdapterWrap :
             nb::gil_scoped_acquire gil;
             nb::detail::ticket ticket(nb_trampoline, "siteCartesianPosition", true);
 
-            if (!ticket.key.is_valid()) 
+            if (!ticket.key.is_valid())
             {
                 throw nb::type_error(
                     "pure virtual method StructureAdapter.siteCartesianPosition() called"
@@ -428,7 +428,7 @@ class StructureAdapterWrap :
             nb::gil_scoped_acquire gil;
             nb::detail::ticket ticket(nb_trampoline, "siteCartesianUij", true);
 
-            if (!ticket.key.is_valid()) 
+            if (!ticket.key.is_valid())
             {
                 throw nb::type_error(
                     "pure virtual method StructureAdapter.siteCartesianUij() called"

--- a/src/extensions/wrap_StructureDifference.cpp
+++ b/src/extensions/wrap_StructureDifference.cpp
@@ -160,6 +160,7 @@ void wrap_StructureDifference(nb::module_& m)
 
     nb::class_<StructureDifference> sd(m, "StructureDifference", doc_StructureDifference);
     sd
+        .def(nb::init<>())
         .def(nb::init<const StructureDifference&>(), nb::arg("sd"),
                     doc_StructureDifference_init_copy)
         .def(nb::init<StructureAdapterPtr, StructureAdapterPtr>(), 

--- a/src/extensions/wrap_StructureDifference.cpp
+++ b/src/extensions/wrap_StructureDifference.cpp
@@ -17,8 +17,7 @@
 *
 *****************************************************************************/
 
-#include <boost/python/class.hpp>
-#include <boost/python/slice.hpp>
+#include <nanobind/nanobind.h>
 
 #include <cstdlib>
 
@@ -27,16 +26,16 @@
 
 #include "srreal_converters.hpp"
 
+namespace nb = nanobind;
+
 namespace srrealmodule {
 
 // declarations
-void sync_StructureDifference(boost::python::object obj);
+void sync_StructureDifference(nb::object obj);
 
 namespace nswrap_StructureDifference {
 
-using namespace boost;
 using namespace diffpy::srreal;
-using boost::python::slice;
 
 // docstrings ----------------------------------------------------------------
 
@@ -72,45 +71,45 @@ from stru0 atoms at indices pop0 and addition of add1 atoms in stru1.\n\
 
 // wrappers ------------------------------------------------------------------
 
-python::list get_pop0(python::object obj)
+nb::list get_pop0(nb::object obj)
 {
-    python::object pypop0 = obj.attr("_pop0");
+    nb::object pypop0 = obj.attr("_pop0");
     if (pypop0.is_none())
     {
         const StructureDifference& sd =
-            python::extract<const StructureDifference&>(obj);
+            nb::cast<const StructureDifference&>(obj);
         pypop0 = obj.attr("_pop0") = convertToPythonList(sd.pop0);
     }
-    return python::extract<python::list>(pypop0);
+    return nb::borrow<nb::list>(pypop0);
 }
 
 
-void set_pop0(python::object obj, python::object value)
+void set_pop0(nb::object obj, nb::object value)
 {
-    StructureDifference& sd = python::extract<StructureDifference&>(obj);
+    StructureDifference& sd = nb::cast<StructureDifference&>(obj);
     sd.pop0 = extractintvector(value);
-    get_pop0(obj)[slice()] = convertToPythonList(sd.pop0);
+    nb::cast<nb::object>(get_pop0(obj))[nb::slice(nb::none(), nb::none(), nb::none())] = convertToPythonList(sd.pop0);
 }
 
 
-python::list get_add1(python::object obj)
+nb::list get_add1(nb::object obj)
 {
-    python::object pyadd1 = obj.attr("_add1");
+    nb::object pyadd1 = obj.attr("_add1");
     if (pyadd1.is_none())
     {
         const StructureDifference& sd =
-            python::extract<const StructureDifference&>(obj);
+            nb::cast<const StructureDifference&>(obj);
         pyadd1 = obj.attr("_add1") = convertToPythonList(sd.add1);
     }
-    return python::extract<python::list>(pyadd1);
+    return nb::borrow<nb::list>(pyadd1);
 }
 
 
-void set_add1(python::object obj, python::object value)
+void set_add1(nb::object obj, nb::object value)
 {
-    StructureDifference& sd = python::extract<StructureDifference&>(obj);
+    StructureDifference& sd = nb::cast<StructureDifference&>(obj);
     sd.add1 = extractintvector(value);
-    get_add1(obj)[slice()] = convertToPythonList(sd.add1);
+    nb::cast<nb::object>(get_pop0(obj))[nb::slice(nb::none(), nb::none(), nb::none())] = convertToPythonList(sd.add1);
 }
 
 
@@ -127,15 +126,14 @@ std::string get_diffmethod(const StructureDifference& sd)
     }
     const char* emsg = "Unknown internal value of StructureDifference::Method.";
     PyErr_SetString(PyExc_NotImplementedError, emsg);
-    boost::python::throw_error_already_set();
-    abort();
+    throw nb::python_error();
 }
 
 
-bool sd_allowsfastupdate(python::object obj)
+bool sd_allowsfastupdate(nb::object obj)
 {
     sync_StructureDifference(obj);
-    StructureDifference& sd = python::extract<StructureDifference&>(obj);
+    StructureDifference& sd = nb::cast<StructureDifference&>(obj);
     return sd.allowsfastupdate();
 }
 
@@ -144,38 +142,34 @@ bool sd_allowsfastupdate(python::object obj)
 // this is a helper function to be called for Python-overridden
 // StructureAdapter::diff method
 
-void sync_StructureDifference(boost::python::object obj)
+void sync_StructureDifference(nb::object obj)
 {
-    using namespace boost::python;
     using diffpy::srreal::StructureDifference;
-    StructureDifference& sd = extract<StructureDifference&>(obj);
-    object pypop0 = obj.attr("_pop0");
+    StructureDifference& sd = nb::cast<StructureDifference&>(obj);
+    nb::object pypop0 = obj.attr("_pop0");
     if (!pypop0.is_none())  sd.pop0 = extractintvector(pypop0);
-    object pyadd1 = obj.attr("_add1");
+    nb::object pyadd1 = obj.attr("_add1");
     if (!pyadd1.is_none())  sd.add1 = extractintvector(pyadd1);
 }
 
 // Wrapper definitions -------------------------------------------------------
 
-void wrap_StructureDifference()
+void wrap_StructureDifference(nb::module_& m)
 {
     using namespace nswrap_StructureDifference;
-    using namespace boost::python;
-    namespace bp = boost::python;
 
-    class_<StructureDifference>("StructureDifference", doc_StructureDifference)
-        .def(init<const StructureDifference&>(bp::arg("sd"),
-                    doc_StructureDifference_init_copy))
-        .def(init<StructureAdapterPtr, StructureAdapterPtr>(
-                    (bp::arg("stru0"), bp::arg("stru1")),
-                    doc_StructureDifference_init_structures))
-        .def_readwrite("stru0", &StructureDifference::stru0)
-        .def_readwrite("stru1", &StructureDifference::stru1)
-        .add_property("pop0", get_pop0, set_pop0)
-        .setattr("_pop0", bp::object())
-        .add_property("add1", get_add1, set_add1)
-        .setattr("_add1", bp::object())
-        .add_property("diffmethod",
+    nb::class_<StructureDifference> sd(m, "StructureDifference", doc_StructureDifference);
+    sd
+        .def(nb::init<const StructureDifference&>(), nb::arg("sd"),
+                    doc_StructureDifference_init_copy)
+        .def(nb::init<StructureAdapterPtr, StructureAdapterPtr>(), 
+                    nb::arg("stru0"), nb::arg("stru1"),
+                    doc_StructureDifference_init_structures)
+        .def_rw("stru0", &StructureDifference::stru0)
+        .def_rw("stru1", &StructureDifference::stru1)
+        .def_prop_rw("pop0", get_pop0, set_pop0)
+        .def_prop_rw("add1", get_add1, set_add1)
+        .def_prop_ro("diffmethod",
                 get_diffmethod,
                 doc_StructureDifference_diffmethod)
         .def("allowsfastupdate",
@@ -183,6 +177,8 @@ void wrap_StructureDifference()
                 doc_StructureDifference_allowsfastupdate)
         ;
 
+    sd.attr("_pop0") = nb::none();
+    sd.attr("_add1") = nb::none();
 }
 
 }   // namespace srrealmodule

--- a/src/extensions/wrap_StructureDifference.cpp
+++ b/src/extensions/wrap_StructureDifference.cpp
@@ -109,7 +109,7 @@ void set_add1(nb::object obj, nb::object value)
 {
     StructureDifference& sd = nb::cast<StructureDifference&>(obj);
     sd.add1 = extractintvector(value);
-    nb::cast<nb::object>(get_pop0(obj))[nb::slice(nb::none(), nb::none(), nb::none())] = convertToPythonList(sd.add1);
+    nb::cast<nb::object>(get_add1(obj))[nb::slice(nb::none(), nb::none(), nb::none())] = convertToPythonList(sd.add1);
 }
 
 
@@ -158,7 +158,8 @@ void wrap_StructureDifference(nb::module_& m)
 {
     using namespace nswrap_StructureDifference;
 
-    nb::class_<StructureDifference> sd(m, "StructureDifference", doc_StructureDifference);
+    nb::class_<StructureDifference> sd(m, "StructureDifference",
+            doc_StructureDifference, nb::dynamic_attr());
     sd
         .def(nb::init<>())
         .def(nb::init<const StructureDifference&>(), nb::arg("sd"),

--- a/src/extensions/wrap_StructureDifference.cpp
+++ b/src/extensions/wrap_StructureDifference.cpp
@@ -164,7 +164,7 @@ void wrap_StructureDifference(nb::module_& m)
         .def(nb::init<>())
         .def(nb::init<const StructureDifference&>(), nb::arg("sd"),
                     doc_StructureDifference_init_copy)
-        .def(nb::init<StructureAdapterPtr, StructureAdapterPtr>(), 
+        .def(nb::init<StructureAdapterPtr, StructureAdapterPtr>(),
                     nb::arg("stru0"), nb::arg("stru1"),
                     doc_StructureDifference_init_structures)
         .def_rw("stru0", &StructureDifference::stru0)

--- a/src/extensions/wrap_libdiffpy_version.cpp
+++ b/src/extensions/wrap_libdiffpy_version.cpp
@@ -17,13 +17,12 @@
 *****************************************************************************/
 
 #include <diffpy/version.hpp>
-#include <boost/python/dict.hpp>
-#include <boost/python/def.hpp>
+#include <nanobind/nanobind.h>
+
+namespace nb = nanobind;
 
 namespace srrealmodule {
 namespace nswrap_libdiffpy_version {
-
-using namespace boost;
 
 // docstrings ----------------------------------------------------------------
 
@@ -33,9 +32,9 @@ Return dictionary with version data for the loaded libdiffpy library.\n\
 
 // wrappers ------------------------------------------------------------------
 
-python::dict get_libdiffpy_version_info_dict()
+nb::dict get_libdiffpy_version_info_dict()
 {
-    python::dict rv;
+    nb::dict rv;
     // Obtain version data from runtime values.
     rv["version"] = libdiffpy_version_info::version;
     rv["version_str"] = libdiffpy_version_info::version_str;
@@ -52,12 +51,11 @@ python::dict get_libdiffpy_version_info_dict()
 
 // Wrapper definition --------------------------------------------------------
 
-void wrap_libdiffpy_version()
+void wrap_libdiffpy_version(nb::module_& m)
 {
     using namespace nswrap_libdiffpy_version;
-    using boost::python::def;
 
-    def("_get_libdiffpy_version_info_dict",
+    m.def("_get_libdiffpy_version_info_dict",
             get_libdiffpy_version_info_dict,
             doc__get_libdiffpy_version_info_dict);
 

--- a/tests/test_atomradiitable.py
+++ b/tests/test_atomradiitable.py
@@ -2,7 +2,6 @@
 
 """Unit tests for the AtomRadiiTable class."""
 
-
 import pickle
 import unittest
 

--- a/tests/test_attributes.py
+++ b/tests/test_attributes.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 
-"""Unit tests for the wrapped diffpy::Attributes
-"""
-
+"""Unit tests for the wrapped diffpy::Attributes"""
 
 import gc
 import unittest

--- a/tests/test_bondcalculator.py
+++ b/tests/test_bondcalculator.py
@@ -2,7 +2,6 @@
 
 """Unit tests for diffpy.srreal.bondcalculator."""
 
-
 import pickle
 import unittest
 

--- a/tests/test_bvscalculator.py
+++ b/tests/test_bvscalculator.py
@@ -2,7 +2,6 @@
 
 """Unit tests for diffpy.srreal.bvscalculator."""
 
-
 import pickle
 import unittest
 

--- a/tests/test_debyepdfcalculator.py
+++ b/tests/test_debyepdfcalculator.py
@@ -2,7 +2,6 @@
 
 """Unit tests for pdfcalculator.py."""
 
-
 import pickle
 import unittest
 import warnings

--- a/tests/test_overlapcalculator.py
+++ b/tests/test_overlapcalculator.py
@@ -2,7 +2,6 @@
 
 """Unit tests for diffpy.srreal.overlapcalculator."""
 
-
 import copy
 import pickle
 import unittest

--- a/tests/test_parallel.py
+++ b/tests/test_parallel.py
@@ -2,7 +2,6 @@
 
 """Unit tests for diffpy.srreal.parallel."""
 
-
 import multiprocessing
 import unittest
 

--- a/tests/test_pdfbaseline.py
+++ b/tests/test_pdfbaseline.py
@@ -3,7 +3,6 @@
 """Unit tests for the PDFBaseline class from
 diffpy.srreal.pdfcalculator."""
 
-
 import pickle
 import unittest
 

--- a/tests/test_pdfcalcobjcryst.py
+++ b/tests/test_pdfcalcobjcryst.py
@@ -2,7 +2,6 @@
 
 """Unit tests for pdfcalculator.py on ObjCryst crystal structures."""
 
-
 import re
 import unittest
 

--- a/tests/test_pdfcalculator.py
+++ b/tests/test_pdfcalculator.py
@@ -2,7 +2,6 @@
 
 """Unit tests for diffpy.srreal.pdfcalculator."""
 
-
 import pickle
 import unittest
 

--- a/tests/test_pdfenvelope.py
+++ b/tests/test_pdfenvelope.py
@@ -3,7 +3,6 @@
 """Unit tests for the PDFEnvelope class from
 diffpy.srreal.pdfcalculator."""
 
-
 import pickle
 import unittest
 

--- a/tests/test_peakprofile.py
+++ b/tests/test_peakprofile.py
@@ -3,7 +3,6 @@
 """Unit tests for the PeakProfile classes from
 diffpy.srreal.peakprofile."""
 
-
 import pickle
 import unittest
 

--- a/tests/test_peakwidthmodel.py
+++ b/tests/test_peakwidthmodel.py
@@ -3,7 +3,6 @@
 """Unit tests for the PeakWidthModel classes from
 diffpy.srreal.peakwidthmodel."""
 
-
 import pickle
 import unittest
 

--- a/tests/test_scatteringfactortable.py
+++ b/tests/test_scatteringfactortable.py
@@ -2,7 +2,6 @@
 
 """Unit tests for diffpy.srreal.scatteringfactortable."""
 
-
 import pickle
 import unittest
 

--- a/tests/test_sfaverage.py
+++ b/tests/test_sfaverage.py
@@ -2,7 +2,6 @@
 
 """Unit tests for diffpy.srreal.sfaverage."""
 
-
 import unittest
 
 import numpy

--- a/tests/test_structureadapter.py
+++ b/tests/test_structureadapter.py
@@ -2,7 +2,6 @@
 
 """Unit tests for diffpy.srreal.structureadapter."""
 
-
 import pickle
 import unittest
 

--- a/tests/testutils.py
+++ b/tests/testutils.py
@@ -2,7 +2,6 @@
 
 """Helper routines for running other unit tests."""
 
-
 import copy
 import pickle
 

--- a/tests/testutils.py
+++ b/tests/testutils.py
@@ -82,7 +82,7 @@ class HasCustomPQConfig(object):
     def _customPQConfig(self, pqobj):
         self.cpqcount += 1
         return
-    
+
 
 def _installCustomPQConfig(cls):
     """Install the test custom-PQ hook without using a mixin base."""

--- a/tests/testutils.py
+++ b/tests/testutils.py
@@ -82,9 +82,17 @@ class HasCustomPQConfig(object):
     def _customPQConfig(self, pqobj):
         self.cpqcount += 1
         return
+    
+
+def _installCustomPQConfig(cls):
+    """Install the test custom-PQ hook without using a mixin base."""
+    cls.cpqcount = HasCustomPQConfig.cpqcount
+    cls._customPQConfig = HasCustomPQConfig._customPQConfig
+    return cls
 
 
-class DerivedStructureAdapter(HasCustomPQConfig, StructureAdapter):
+@_installCustomPQConfig
+class DerivedStructureAdapter(StructureAdapter):
 
     def __init__(self):
         StructureAdapter.__init__(self)
@@ -137,19 +145,18 @@ class DerivedStructureAdapter(HasCustomPQConfig, StructureAdapter):
 # End of class DerivedStructureAdapter
 
 
-class DerivedAtomicStructureAdapter(HasCustomPQConfig, AtomicStructureAdapter):
+@_installCustomPQConfig
+class DerivedAtomicStructureAdapter(AtomicStructureAdapter):
     pass
 
 
-class DerivedPeriodicStructureAdapter(
-    HasCustomPQConfig, PeriodicStructureAdapter
-):
+@_installCustomPQConfig
+class DerivedPeriodicStructureAdapter(PeriodicStructureAdapter):
     pass
 
 
-class DerivedCrystalStructureAdapter(
-    HasCustomPQConfig, CrystalStructureAdapter
-):
+@_installCustomPQConfig
+class DerivedCrystalStructureAdapter(CrystalStructureAdapter):
     pass
 
 


### PR DESCRIPTION
This PR is the initial port that migrates the original Boost.Python bindings to nanobind as mentioned in diffpy/pyobjcryst#88, noticed future improvements will be mentioned in TODOs but will be addressed in future PRs.