### PR TITLE
chore: updated pre-commit hook dependencies

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,7 @@ ci:
   submodules: false
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.6.0
+    rev: v6.0.0
     hooks:
       - id: check-yaml
       - id: end-of-file-fixer
@@ -21,31 +21,31 @@ repos:
       - id: check-toml
       - id: check-added-large-files
   - repo: https://github.com/psf/black
-    rev: 24.4.2
+    rev: 26.3.1
     hooks:
       - id: black
   - repo: https://github.com/pycqa/flake8
-    rev: 7.0.0
+    rev: 7.3.0
     hooks:
       - id: flake8
   - repo: https://github.com/pycqa/isort
-    rev: 5.13.2
+    rev: 9.0.0a3
     hooks:
       - id: isort
         args: ["--profile", "black"]
   - repo: https://github.com/kynan/nbstripout
-    rev: 0.7.1
+    rev: 0.9.1
     hooks:
       - id: nbstripout
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.4.0
+    rev: v6.0.0
     hooks:
       - id: no-commit-to-branch
         name: Prevent Commit to Main Branch
         args: ["--branch", "main"]
         stages: [pre-commit]
   - repo: https://github.com/codespell-project/codespell
-    rev: v2.3.0
+    rev: v2.4.2
     hooks:
       - id: codespell
         additional_dependencies:
@@ -58,8 +58,8 @@ repos:
         additional_dependencies:
           - "prettier@^3.2.4"
   # docformatter - PEP 257 compliant docstring formatter
-  - repo: https://github.com/s-weigand/docformatter
-    rev: 5757c5190d95e5449f102ace83df92e7d3b06c6c
+  - repo: https://github.com/PyCQA/docformatter
+    rev: v1.7.8
     hooks:
       - id: docformatter
         additional_dependencies: [tomli]

--- a/news/precommit-deps-update.rst
+++ b/news/precommit-deps-update.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* No news needed: updating pre-commit hooks, black, flake8, isort, nbstripout, codespell and docformatter. Not user facing.
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/src/diffpy/__init__.py
+++ b/src/diffpy/__init__.py
@@ -14,7 +14,6 @@
 ##############################################################################
 """Blank namespace package for module diffpy."""
 
-
 from pkgutil import extend_path
 
 __path__ = extend_path(__path__, __name__)

--- a/src/diffpy/srreal/_cleanup.py
+++ b/src/diffpy/srreal/_cleanup.py
@@ -24,7 +24,6 @@ This module is not intended for direct use.  It is used implicitly within
 a call of _registerThisType.
 """
 
-
 import atexit
 import weakref
 

--- a/src/diffpy/srreal/_final_imports.py
+++ b/src/diffpy/srreal/_final_imports.py
@@ -15,13 +15,15 @@
 """Finalize tweak of classes from the extension module srreal_ext.
 
 This private module handles loading of Python-level tweaks of the
-extension-defined classes.  Any client that imports this module
-must call the `import_now` function.  If this module is not loaded
-by the time of srreal_ext initialization, `import_now` is executed
-from srreal_ext.
+extension-defined classes.  Any client that imports this module must
+call the `import_now` function.  If this module is not loaded by the
+time of srreal_ext initialization, `import_now` is executed from
+srreal_ext.
 
 This avoids unresolvable import dependencies for any order of imports.
 """
+
+_import_now_called = False
 
 
 def import_now():
@@ -46,6 +48,3 @@ def import_now():
     import_module("diffpy.srreal.pdfcalculator")
     import_module("diffpy.srreal.structureconverters")
     return
-
-
-_import_now_called = False

--- a/src/diffpy/srreal/atomradiitable.py
+++ b/src/diffpy/srreal/atomradiitable.py
@@ -14,7 +14,6 @@
 ##############################################################################
 """Class AtomRadiiTable -- storage of empirical atom radii."""
 
-
 # exported items, these also makes them show in pydoc.
 __all__ = ["AtomRadiiTable", "ConstantRadiiTable", "CovalentRadiiTable"]
 
@@ -66,8 +65,9 @@ class CovalentRadiiTable(AtomRadiiTable):
         return copy.copy(self)
 
     def type(self):
-        """Unique string identifier of the CovalentRadiiTable type. This
-        is used for class registration and as an argument for the
+        """Unique string identifier of the CovalentRadiiTable type.
+
+        This is used for class registration and as an argument for the
         createByType function.
 
         Return string.

--- a/src/diffpy/srreal/attributes.py
+++ b/src/diffpy/srreal/attributes.py
@@ -13,7 +13,7 @@
 #
 ##############################################################################
 """class Attributes  -- wrapper to C++ class diffpy::Attributes
-    A base to PairQuantity and quite a few other classes.
+A base to PairQuantity and quite a few other classes.
 """
 
 __all__ = ["Attributes"]

--- a/src/diffpy/srreal/bondcalculator.py
+++ b/src/diffpy/srreal/bondcalculator.py
@@ -14,7 +14,6 @@
 ##############################################################################
 """Class BondCalculator -- distances between atoms in the structure."""
 
-
 # exported items, these also makes them show in pydoc.
 __all__ = ["BondCalculator"]
 
@@ -28,14 +27,12 @@ from diffpy.srreal.wraputils import (
 
 BondCalculator.rmin = propertyFromExtDoubleAttr(
     "rmin",
-    """Lower bound for the bond distances.
-        [0 A]""",
+    "Lower bound for the bond distances. [0 A]",
 )
 
 BondCalculator.rmax = propertyFromExtDoubleAttr(
     "rmax",
-    """Upper bound for the bond distances.
-        [5 A]""",
+    "Upper bound for the bond distances. [5 A]",
 )
 
 

--- a/src/diffpy/srreal/bvparameterstable.py
+++ b/src/diffpy/srreal/bvparameterstable.py
@@ -15,7 +15,6 @@
 """Class BVParametersTable -- storage of bond valence parameters class BVParam
 -- bond valence data associated with specific cation-anion pair."""
 
-
 # exported items, these also makes them show in pydoc.
 __all__ = ["BVParam", "BVParametersTable"]
 

--- a/src/diffpy/srreal/bvscalculator.py
+++ b/src/diffpy/srreal/bvscalculator.py
@@ -14,7 +14,6 @@
 ##############################################################################
 """Class BVSCalculator -- bond valence sums calculator."""
 
-
 # exported items
 __all__ = ["BVSCalculator"]
 
@@ -28,30 +27,32 @@ from diffpy.srreal.wraputils import (
 
 BVSCalculator.valenceprecision = propertyFromExtDoubleAttr(
     "valenceprecision",
-    """Cutoff value for valence contributions at long distances.
-        [1e-5]""",
+    "Cutoff value for valence contributions at long distances. [1e-5]",
 )
 
 BVSCalculator.rmaxused = propertyFromExtDoubleAttr(
     "rmaxused",
-    """Effective bound for bond lengths, where valence contributions
-        become smaller than valenceprecission, read-only.  Always smaller or
-        equal to rmax.  The value depends on ions present in the structure.
-        """,
+    (
+        "Effective bound for bond lengths, where valence contributions"
+        " become smaller than valenceprecission, read-only."
+        "  Always smaller or equal to rmax."
+        "  The value depends on ions present in the structure."
+    ),
 )
 
 BVSCalculator.rmin = propertyFromExtDoubleAttr(
     "rmin",
-    """Lower bound for the summed bond lengths.
-        [0 A]""",
+    "Lower bound for the summed bond lengths. [0 A]",
 )
 
 BVSCalculator.rmax = propertyFromExtDoubleAttr(
     "rmax",
-    """Upper bound for the summed bond lengths.  The calculation is
-        actually cut off much earlier when valence contributions get below
-        valenceprecission.  See also rmaxused and valenceprecission.
-        [1e6 A]""",
+    (
+        "Upper bound for the summed bond lengths."
+        "  The calculation is actually cut off much earlier when"
+        " valence contributions get below valenceprecission."
+        "  See also rmaxused and valenceprecission. [1e6 A]"
+    ),
 )
 
 

--- a/src/diffpy/srreal/eventticker.py
+++ b/src/diffpy/srreal/eventticker.py
@@ -15,7 +15,6 @@
 """Class EventTicker -- storage of modification times of dependent
 objects."""
 
-
 # exported items
 __all__ = ["EventTicker"]
 

--- a/src/diffpy/srreal/overlapcalculator.py
+++ b/src/diffpy/srreal/overlapcalculator.py
@@ -15,7 +15,6 @@
 """Class OverlapCalculator -- calculator of atom overlaps in a
 structure."""
 
-
 # exported items, these also makes them show in pydoc.
 __all__ = ["OverlapCalculator"]
 
@@ -29,22 +28,21 @@ from diffpy.srreal.wraputils import (
 
 OverlapCalculator.rmin = propertyFromExtDoubleAttr(
     "rmin",
-    """Lower bound for the bond distances.
-        [0 A]""",
+    "Lower bound for the bond distances. [0 A]",
 )
 
 OverlapCalculator.rmax = propertyFromExtDoubleAttr(
     "rmax",
-    """Upper bound for the bond distances.
-        [5 A]""",
+    "Upper bound for the bond distances. [5 A]",
 )
 
 OverlapCalculator.rmaxused = propertyFromExtDoubleAttr(
     "rmaxused",
-    """Effective upper bound for the bond distances.
-        rmaxused equals either a double of the maximum atom radius
-        in the structure or rmax.
-        """,
+    (
+        "Effective upper bound for the bond distances."
+        " rmaxused equals either a double of the maximum"
+        " atom radius in the structure or rmax."
+    ),
 )
 
 # method overrides that support keyword arguments

--- a/src/diffpy/srreal/pairquantity.py
+++ b/src/diffpy/srreal/pairquantity.py
@@ -15,7 +15,6 @@
 """Class PairQuantity    -- base class for Python defined
 calculators."""
 
-
 # exported items
 __all__ = ["PairQuantity"]
 

--- a/src/diffpy/srreal/parallel.py
+++ b/src/diffpy/srreal/parallel.py
@@ -16,7 +16,6 @@
 into parallel calculators.
 """
 
-
 # exported items
 __all__ = ["createParallelCalculator"]
 
@@ -48,8 +47,10 @@ def createParallelCalculator(pqobj, ncpu, pmap):
     """
 
     class ParallelPairQuantity(Attributes):
-        """Class for running parallel calculations.  This is a proxy
-        class to the wrapper PairQuantity type with the same interface.
+        """Class for running parallel calculations.
+
+        This is a proxy class to the wrapper PairQuantity type
+        with the same interface.
 
         Instance data:
 
@@ -144,7 +145,7 @@ def createParallelCalculator(pqobj, ncpu, pmap):
 
         @property
         def evaluatortype(self):
-            """str : Type of evaluation procedure.
+            """Str : Type of evaluation procedure.
 
             Parallel calculations allow only the 'BASIC' type.
             """
@@ -166,11 +167,9 @@ def createParallelCalculator(pqobj, ncpu, pmap):
 
     # create proxy methods to all public methods and some protected methods
 
-    proxy_forced = set(
-        """_getDoubleAttr _setDoubleAttr _hasDoubleAttr
+    proxy_forced = set("""_getDoubleAttr _setDoubleAttr _hasDoubleAttr
         _namesOfDoubleAttributes _namesOfWritableDoubleAttributes
-        """.split()
-    )
+        """.split())
 
     def _make_proxymethod(name, f):
         def proxymethod(self, *args, **kwargs):

--- a/src/diffpy/srreal/pdfbaseline.py
+++ b/src/diffpy/srreal/pdfbaseline.py
@@ -17,7 +17,6 @@ Classes for configuring PDF baseline:
     PDFBaseline, ZeroBaseline, LinearBaseline
 """
 
-
 # exported items
 __all__ = """
     PDFBaseline makePDFBaseline
@@ -40,8 +39,10 @@ ZeroBaseline.__getstate_manages_dict__ = None
 
 LinearBaseline.slope = propertyFromExtDoubleAttr(
     "slope",
-    """Slope of an unscaled linear baseline.  For crystal structures it
-    is preset to (-4 * pi * rho0).""",
+    (
+        "Slope of an unscaled linear baseline.  For crystal structures it"
+        " is preset to (-4 * pi * rho0)."
+    ),
 )
 
 # Python functions wrapper

--- a/src/diffpy/srreal/pdfcalculator.py
+++ b/src/diffpy/srreal/pdfcalculator.py
@@ -88,77 +88,78 @@ assert all(
 def _defineCommonInterface(cls):
     """This function defines shared properties of PDF calculator
     classes."""
-
     cls.scale = propertyFromExtDoubleAttr(
         "scale",
-        """Scale factor of the calculated PDF.  Active for ScaleEnvelope.
-        [1.0 unitless]""",
+        (
+            "Scale factor of the calculated PDF."
+            "  Active for ScaleEnvelope. [1.0 unitless]"
+        ),
     )
 
     cls.delta1 = propertyFromExtDoubleAttr(
         "delta1",
-        """Coefficient for (1/r) contribution to the peak sharpening.
-        Active for JeongPeakWidth model.
-        [0 A]""",
+        (
+            "Coefficient for (1/r) contribution to the peak sharpening."
+            "  Active for JeongPeakWidth model. [0 A]"
+        ),
     )
 
     cls.delta2 = propertyFromExtDoubleAttr(
         "delta2",
-        """Coefficient for (1/r**2) contribution to the peak sharpening.
-        Active for JeongPeakWidth model.
-        [0 A**2]""",
+        (
+            "Coefficient for (1/r**2) contribution to the peak sharpening."
+            "  Active for JeongPeakWidth model. [0 A**2]"
+        ),
     )
 
     cls.qdamp = propertyFromExtDoubleAttr(
         "qdamp",
-        """PDF Gaussian dampening factor due to limited Q-resolution.
-        Not applied when equal to zero.  Active for QResolutionEnvelope.
-        [0 1/A]""",
+        (
+            "PDF Gaussian dampening factor due to limited Q-resolution."
+            "  Not applied when equal to zero."
+            "  Active for QResolutionEnvelope. [0 1/A]"
+        ),
     )
 
     cls.qbroad = propertyFromExtDoubleAttr(
         "qbroad",
-        """PDF peak broadening from increased intensity noise at high Q.
-        Not applied when equal zero.  Active for JeongPeakWidth model.
-        [0 1/A]""",
+        (
+            "PDF peak broadening from increased intensity noise at high Q."
+            "  Not applied when equal zero."
+            "  Active for JeongPeakWidth model. [0 1/A]"
+        ),
     )
 
     cls.extendedrmin = propertyFromExtDoubleAttr(
         "extendedrmin",
-        """Low boundary of the extended r-range, read-only.
-        [A]""",
+        "Low boundary of the extended r-range, read-only. [A]",
     )
 
     cls.extendedrmax = propertyFromExtDoubleAttr(
         "extendedrmax",
-        """Upper boundary of the extended r-range, read-only.
-        [A]""",
+        "Upper boundary of the extended r-range, read-only. [A]",
     )
-
     cls.maxextension = propertyFromExtDoubleAttr(
         "maxextension",
-        """Maximum extension of the r-range that accounts for contributions
-        from the out of range peaks.
-        [10 A]""",
+        (
+            "Maximum extension of the r-range that accounts for"
+            " contributions from the out of range peaks. [10 A]"
+        ),
     )
-
     cls.rmin = propertyFromExtDoubleAttr(
         "rmin",
-        """Lower bound of the r-grid for PDF calculation.
-        [0 A]""",
+        "Lower bound of the r-grid for PDF calculation. [0 A]",
     )
-
     cls.rmax = propertyFromExtDoubleAttr(
         "rmax",
-        """Upper bound of the r-grid for PDF calculation.
-        [10 A]""",
+        "Upper bound of the r-grid for PDF calculation. [10 A]",
     )
-
     cls.rstep = propertyFromExtDoubleAttr(
         "rstep",
-        """Spacing in the calculated r-grid.  r-values are at the
-        multiples of rstep.
-        [0.01 A]""",
+        (
+            "Spacing in the calculated r-grid."
+            "  r-values are at the multiples of rstep. [0.01 A]"
+        ),
     )
 
     def _call_kwargs(self, structure=None, **kwargs):
@@ -197,36 +198,36 @@ def _defineCommonInterface(cls):
 # shared interface of the PDF calculator classes
 
 _defineCommonInterface(DebyePDFCalculator)
-
 # Property wrappers to double attributes of the C++ DebyePDFCalculator
 
 DebyePDFCalculator.debyeprecision = propertyFromExtDoubleAttr(
     "debyeprecision",
-    """Cutoff amplitude for the sine contributions to the F(Q).
-        [1e-6 unitless]""",
+    "Cutoff amplitude for the sine contributions to the F(Q). [1e-6 unitless]",
 )
 
 DebyePDFCalculator.qmin = propertyFromExtDoubleAttr(
     "qmin",
-    """Lower bound of the Q-grid for the calculated F(Q).
-        Affects the shape envelope.
-        [0 1/A]
-        """,
+    (
+        "Lower bound of the Q-grid for the calculated F(Q)."
+        "  Affects the shape envelope. [0 1/A]"
+    ),
 )
 
 DebyePDFCalculator.qmax = propertyFromExtDoubleAttr(
     "qmax",
-    """Upper bound of the Q-grid for the calculated F(Q).
-        Affects the termination ripples.
-        [25 1/A]
-        """,
+    (
+        "Upper bound of the Q-grid for the calculated F(Q)."
+        "  Affects the termination ripples. [25 1/A]"
+    ),
 )
 
 DebyePDFCalculator.qstep = propertyFromExtDoubleAttr(
     "qstep",
-    """Spacing in the Q-grid.  Q-values are at the multiples of qstep.
-        [PI/extendedrmax A] unless user overridden.
-        See also setOptimumQstep, isOptimumQstep.""",
+    (
+        "Spacing in the Q-grid."
+        "  Q-values are at the multiples of qstep. [PI/extendedrmax A]"
+        " unless user overridden.  See also setOptimumQstep, isOptimumQstep."
+    ),
 )
 
 # method overrides to support optional keyword arguments
@@ -248,7 +249,6 @@ def _init_kwargs0(self, **kwargs):
 
 DebyePDFCalculator.__boostpython__init = DebyePDFCalculator.__init__
 DebyePDFCalculator.__init__ = _init_kwargs0
-
 # End of class DebyePDFCalculator
 
 # PDFCalculator --------------------------------------------------------------
@@ -261,53 +261,62 @@ _defineCommonInterface(PDFCalculator)
 
 PDFCalculator.peakprecision = propertyFromExtDoubleAttr(
     "peakprecision",
-    """Cutoff amplitude of the peak tail relative to the peak maximum.
-        [3.33e-6 unitless]""",
+    (
+        "Cutoff amplitude of the peak tail relative to the peak maximum."
+        " [3.33e-6 unitless]"
+    ),
 )
-
 PDFCalculator.qmin = propertyFromExtDoubleAttr(
     "qmin",
-    """Lower bound of the experimental Q-range used.
-        Affects the shape envelope.
-        [0 1/A]""",
+    (
+        "Lower bound of the experimental Q-range used."
+        "  Affects the shape envelope. [0 1/A]"
+    ),
 )
-
 PDFCalculator.qmax = propertyFromExtDoubleAttr(
     "qmax",
-    """Upper bound of the experimental Q-range used.
-        Affects the termination ripples.  Not used when zero.
-        [0 1/A]""",
+    (
+        "Upper bound of the experimental Q-range used."
+        "  Affects the termination ripples.  Not used when zero. [0 1/A]"
+    ),
 )
-
 PDFCalculator.qstep = propertyFromExtDoubleAttr(
     "qstep",
-    """Spacing in the Q-grid.  Q-values are at the multiples of qstep.
-        The value is padded by rsteps so that PI/qstep > extendedrmax and
-        PI/(qstep * rstep) is a power of 2.  Read-only.
-        [PI/(padded extendedrmax) A]""",
+    (
+        "Spacing in the Q-grid."
+        "  Q-values are at the multiples of qstep. The value is padded"
+        " by rsteps so that PI/qstep > extendedrmax and"
+        " PI/(qstep * rstep) is a power of 2.  Read-only."
+        " [PI/(padded extendedrmax) A]"
+    ),
 )
 
 PDFCalculator.slope = propertyFromExtDoubleAttr(
     "slope",
-    """Slope of the linear PDF background.  Assigned according to
-        number density of the evaluated structure at each PDF calculation.
-        Active for LinearBaseline.
-        [-4*pi*numdensity unitless]""",
+    (
+        "Slope of the linear PDF background."
+        "  Assigned according to number density of the evaluated"
+        " structure at each PDF calculation. Active for LinearBaseline."
+        " [-4*pi*numdensity unitless]"
+    ),
 )
 
 PDFCalculator.spdiameter = propertyFromExtDoubleAttr(
     "spdiameter",
-    """Spherical particle diameter for PDF shape damping correction.
-        Not used when zero.  Active for SphericalShapeEnvelope.
-        [0 A]""",
+    (
+        "Spherical particle diameter for PDF shape damping correction."
+        "  Not used when zero.  Active for SphericalShapeEnvelope. [0 A]"
+    ),
 )
 
 PDFCalculator.stepcut = propertyFromExtDoubleAttr(
     "stepcut",
-    """r-boundary for a step cutoff of the calculated PDF.
-        Not used when negative or zero.  Active for StepCutEnvelope.
-        Not used when zero.  Active for StepCutEnvelope.
-        [0 A]""",
+    (
+        "r-boundary for a step cutoff of the calculated PDF."
+        "  Not used when negative or zero.  Active for StepCutEnvelope."
+        "  Not used when zero.  Active for StepCutEnvelope."
+        " [0 A]"
+    ),
 )
 
 # method overrides to support optional keyword arguments

--- a/src/diffpy/srreal/pdfenvelope.py
+++ b/src/diffpy/srreal/pdfenvelope.py
@@ -18,7 +18,6 @@ Classes for configuring PDF scaling envelope:
     SphericalShapeEnvelope, StepCutEnvelope
 """
 
-
 # exported items
 __all__ = """
    PDFEnvelope makePDFEnvelope
@@ -51,26 +50,22 @@ StepCutEnvelope.__getstate_manages_dict__ = None
 
 QResolutionEnvelope.qdamp = propertyFromExtDoubleAttr(
     "qdamp",
-    """Dampening parameter in the Gaussian envelope function.
-    """,
+    "Dampening parameter in the Gaussian envelope function.",
 )
 
 ScaleEnvelope.scale = propertyFromExtDoubleAttr(
     "scale",
-    """Overall scale for a uniform scaling envelope.
-    """,
+    "Overall scale for a uniform scaling envelope.",
 )
 
 SphericalShapeEnvelope.spdiameter = propertyFromExtDoubleAttr(
     "spdiameter",
-    """Particle diameter in Angstroms for a spherical shape damping.
-    """,
+    "Particle diameter in Angstroms for a spherical shape damping.",
 )
 
 StepCutEnvelope.stepcut = propertyFromExtDoubleAttr(
     "stepcut",
-    """Cutoff for a step-function envelope.
-    """,
+    "Cutoff for a step-function envelope.",
 )
 
 # Python functions wrapper

--- a/src/diffpy/srreal/peakprofile.py
+++ b/src/diffpy/srreal/peakprofile.py
@@ -18,7 +18,6 @@ Class for configuring PDF profile function:
     GaussianProfile, CroppedGaussianProfile
 """
 
-
 # exported items
 __all__ = ["PeakProfile", "GaussianProfile", "CroppedGaussianProfile"]
 
@@ -41,9 +40,11 @@ CroppedGaussianProfile.__getstate_manages_dict__ = None
 
 PeakProfile.peakprecision = propertyFromExtDoubleAttr(
     "peakprecision",
-    """Profile amplitude relative to the peak maximum for evaluating peak
-    bounds xboundlo and xboundhi. [3.33e-6 unitless]
-    """,
+    (
+        "Profile amplitude relative to the peak maximum for evaluating "
+        "peak bounds xboundlo and xboundhi.\n\n"
+        "[3.33e-6 unitless]"
+    ),
 )
 
 # Import delayed tweaks of the extension classes.

--- a/src/diffpy/srreal/peakwidthmodel.py
+++ b/src/diffpy/srreal/peakwidthmodel.py
@@ -18,7 +18,6 @@ Classes for configuring peak width evaluation in PDF calculations:
     ConstantPeakWidth, DebyeWallerPeakWidth, JeongPeakWidth
 """
 
-
 # exported items
 __all__ = [
     "PeakWidthModel",
@@ -42,20 +41,17 @@ from diffpy.srreal.wraputils import propertyFromExtDoubleAttr
 
 ConstantPeakWidth.width = propertyFromExtDoubleAttr(
     "width",
-    """Constant FWHM value returned by this model.
-    """,
+    "Constant FWHM value returned by this model.",
 )
 
 ConstantPeakWidth.bisowidth = propertyFromExtDoubleAttr(
     "bisowidth",
-    """Equivalent uniform Biso for this constant `width`.
-    """,
+    "Equivalent uniform Biso for this constant `width`.",
 )
 
 ConstantPeakWidth.uisowidth = propertyFromExtDoubleAttr(
     "uisowidth",
-    """Equivalent uniform Uiso for this constant `width`.
-    """,
+    "Equivalent uniform Uiso for this constant `width`.",
 )
 
 JeongPeakWidth.delta1 = propertyFromExtDoubleAttr(

--- a/src/diffpy/srreal/scatteringfactortable.py
+++ b/src/diffpy/srreal/scatteringfactortable.py
@@ -15,7 +15,6 @@
 """Class ScatteringFactorTable -- scattering factors for atoms, ions and
 isotopes."""
 
-
 # exported items, these also makes them show in pydoc.
 __all__ = [
     "ScatteringFactorTable",

--- a/src/diffpy/srreal/sfaverage.py
+++ b/src/diffpy/srreal/sfaverage.py
@@ -33,7 +33,6 @@ Examples
                                      dpdfc.scatteringfactortable, dpdfc.qgrid)
 """
 
-
 # class SFAverage ------------------------------------------------------------
 
 

--- a/src/diffpy/srreal/wraputils.py
+++ b/src/diffpy/srreal/wraputils.py
@@ -15,7 +15,6 @@
 """Local utilities helpful for tweaking interfaces to boost python
 classes."""
 
-
 import copy
 
 # Routines -------------------------------------------------------------------
@@ -111,9 +110,10 @@ def _wrapAsRegisteredUnaryFunction(
             return copy.copy(self)
 
         def type(self):
-            """Unique string identifier of this functor type.  The
-            string is used for class registration and as an argument for
-            the createByType function.
+            """Unique string identifier of this functor type.
+
+            The string is used for class registration and as an argument
+            for the createByType function.
 
             Return string identifier.
             """

--- a/tests/test_atomradiitable.py
+++ b/tests/test_atomradiitable.py
@@ -2,7 +2,6 @@
 
 """Unit tests for the AtomRadiiTable class."""
 
-
 import pickle
 import unittest
 

--- a/tests/test_attributes.py
+++ b/tests/test_attributes.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 
-"""Unit tests for the wrapped diffpy::Attributes
-"""
-
+"""Unit tests for the wrapped diffpy::Attributes"""
 
 import gc
 import unittest

--- a/tests/test_bondcalculator.py
+++ b/tests/test_bondcalculator.py
@@ -2,7 +2,6 @@
 
 """Unit tests for diffpy.srreal.bondcalculator."""
 
-
 import pickle
 import unittest
 

--- a/tests/test_bvscalculator.py
+++ b/tests/test_bvscalculator.py
@@ -2,7 +2,6 @@
 
 """Unit tests for diffpy.srreal.bvscalculator."""
 
-
 import pickle
 import unittest
 

--- a/tests/test_debyepdfcalculator.py
+++ b/tests/test_debyepdfcalculator.py
@@ -2,7 +2,6 @@
 
 """Unit tests for pdfcalculator.py."""
 
-
 import pickle
 import unittest
 import warnings

--- a/tests/test_overlapcalculator.py
+++ b/tests/test_overlapcalculator.py
@@ -2,7 +2,6 @@
 
 """Unit tests for diffpy.srreal.overlapcalculator."""
 
-
 import copy
 import pickle
 import unittest

--- a/tests/test_parallel.py
+++ b/tests/test_parallel.py
@@ -2,7 +2,6 @@
 
 """Unit tests for diffpy.srreal.parallel."""
 
-
 import multiprocessing
 import unittest
 

--- a/tests/test_pdfbaseline.py
+++ b/tests/test_pdfbaseline.py
@@ -3,7 +3,6 @@
 """Unit tests for the PDFBaseline class from
 diffpy.srreal.pdfcalculator."""
 
-
 import pickle
 import unittest
 

--- a/tests/test_pdfcalcobjcryst.py
+++ b/tests/test_pdfcalcobjcryst.py
@@ -2,7 +2,6 @@
 
 """Unit tests for pdfcalculator.py on ObjCryst crystal structures."""
 
-
 import re
 import unittest
 

--- a/tests/test_pdfcalculator.py
+++ b/tests/test_pdfcalculator.py
@@ -2,7 +2,6 @@
 
 """Unit tests for diffpy.srreal.pdfcalculator."""
 
-
 import pickle
 import unittest
 

--- a/tests/test_pdfenvelope.py
+++ b/tests/test_pdfenvelope.py
@@ -3,7 +3,6 @@
 """Unit tests for the PDFEnvelope class from
 diffpy.srreal.pdfcalculator."""
 
-
 import pickle
 import unittest
 

--- a/tests/test_peakprofile.py
+++ b/tests/test_peakprofile.py
@@ -3,7 +3,6 @@
 """Unit tests for the PeakProfile classes from
 diffpy.srreal.peakprofile."""
 
-
 import pickle
 import unittest
 

--- a/tests/test_peakwidthmodel.py
+++ b/tests/test_peakwidthmodel.py
@@ -3,7 +3,6 @@
 """Unit tests for the PeakWidthModel classes from
 diffpy.srreal.peakwidthmodel."""
 
-
 import pickle
 import unittest
 

--- a/tests/test_scatteringfactortable.py
+++ b/tests/test_scatteringfactortable.py
@@ -2,7 +2,6 @@
 
 """Unit tests for diffpy.srreal.scatteringfactortable."""
 
-
 import pickle
 import unittest
 

--- a/tests/test_sfaverage.py
+++ b/tests/test_sfaverage.py
@@ -2,7 +2,6 @@
 
 """Unit tests for diffpy.srreal.sfaverage."""
 
-
 import unittest
 
 import numpy

--- a/tests/test_structureadapter.py
+++ b/tests/test_structureadapter.py
@@ -2,7 +2,6 @@
 
 """Unit tests for diffpy.srreal.structureadapter."""
 
-
 import pickle
 import unittest
 

--- a/tests/testutils.py
+++ b/tests/testutils.py
@@ -2,7 +2,6 @@
 
 """Helper routines for running other unit tests."""
 
-
 import copy
 import pickle
 


### PR DESCRIPTION
## Summary

This PR performs pre-commit hook maintenance by updating formatter, linter, and tooling hook revisions.

## Changes

- Updated `pre-commit-hooks` from `v4.6.0` to `v6.0.0`
- Updated `black` from `24.4.2` to `26.3.1`
- Updated `flake8` from `7.0.0` to `7.3.0`
- Updated `isort` from `5.13.2` to `9.0.0a3`
- Updated `nbstripout` from `0.7.1` to `0.9.1`
- Updated `codespell` from `v2.3.0` to `v2.4.2`
- Updated `docformatter` from rev `5757c5190d95e5449f102ace83df92e7d3b06c6c` to `v1.7.8`